### PR TITLE
[B-52] 메모 저장 할 때 Health Kit에 데이터 저장하기

### DIFF
--- a/Booster/Booster/ViewControllers/Tracking/TrackingProgressViewController.swift
+++ b/Booster/Booster/ViewControllers/Tracking/TrackingProgressViewController.swift
@@ -1,5 +1,6 @@
 import UIKit
 import MapKit
+import HealthKit
 import CoreMotion
 
 class TrackingProgressViewController: UIViewController {
@@ -100,8 +101,14 @@ class TrackingProgressViewController: UIViewController {
     }
 
     private func configureNotifications() {
-        NotificationCenter.default.addObserver(self, selector: #selector(self.keyboardWillShow(_:)), name: UIResponder.keyboardWillShowNotification, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(self.keyboardWillHide(_:)), name: UIResponder.keyboardWillHideNotification, object: nil)
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(self.keyboardWillShow(_:)),
+                                               name: UIResponder.keyboardWillShowNotification,
+                                               object: nil)
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(self.keyboardWillHide(_:)),
+                                               name: UIResponder.keyboardWillHideNotification,
+                                               object: nil)
     }
 
     private func bind() {
@@ -279,7 +286,12 @@ class TrackingProgressViewController: UIViewController {
         return text
     }
 
-    private func makeAttributedText(content: String, title: String, contentFont: UIFont = .bazaronite(size: 30), titleFont: UIFont = .notoSansKR(.light, 15), color: UIColor = .black) -> NSMutableAttributedString {
+    private func makeAttributedText(content: String,
+                                    title: String,
+                                    contentFont: UIFont = .bazaronite(size: 30),
+                                    titleFont: UIFont = .notoSansKR(.light, 15),
+                                    color: UIColor = .black)
+    -> NSMutableAttributedString {
         let mutableString = NSMutableAttributedString()
 
         let contentText: NSAttributedString = .makeAttributedString(text: content, font: contentFont, color: color)
@@ -290,6 +302,15 @@ class TrackingProgressViewController: UIViewController {
         }
 
         return mutableString
+    }
+
+    private func save() {
+        viewModel.save { error in
+            guard error == nil else { return }
+            DispatchQueue.main.async {
+                self.navigationController?.popViewController(animated: true)
+            }
+        }
     }
 
     @IBAction func leftTouchUp(_ sender: UIButton) {
@@ -315,10 +336,28 @@ class TrackingProgressViewController: UIViewController {
     @IBAction func rightTouchUp(_ sender: Any) {
         switch viewModel.state {
         case .end:
-            viewModel.save { error in
-                guard error == nil else { return }
-                DispatchQueue.main.async {
-                    self.navigationController?.popViewController(animated: true)
+            let title = "저장 오류"
+            let message = "저장 하기 위해서는 건강앱의 권한이 필요합니다."
+            let store = HKHealthStore()
+            let alert = UIAlertController.simpleAlert(title: title, message: message)
+            var types: Set<HKQuantityType> = []
+            HealthQuantityType.allCases.forEach {
+                if let type = $0.quantity {
+                    types.insert(type)
+                }
+            }
+
+            if HKHealthStore.isHealthDataAvailable() {
+                save()
+            } else {
+                store.requestAuthorization(toShare: types, read: types) { success, error in
+                    if let _ = error {
+                        self.present(alert, animated: true)
+                    } else if success {
+                        self.save()
+                    } else {
+                        self.present(alert, animated: true)
+                    }
                 }
             }
         default:
@@ -333,14 +372,14 @@ class TrackingProgressViewController: UIViewController {
         let timerTime = -Int(timerDate.timeIntervalSinceNow)
         let time = timerTime + lastestTime
         let calroies = Int(60 / 15 * 0.9 * Double((time / 60) % 60))
+        let limit: Double = 300
 
-        pedometer.queryPedometerData(from: Date(timeIntervalSinceNow: -300), to: Date()) { data, _ in
+        pedometer.queryPedometerData(from: Date(timeIntervalSinceNow: -limit), to: Date()) { data, _ in
             guard let data = data, let distance = data.distance?.intValue else { return }
             isMoved = distance > 5
-            print(isMoved, distance, timerTime)
         }
 
-        switch isMoved && timerTime <= 300 {
+        switch isMoved && timerTime <= Int(limit) {
         case true:
             viewModel.update(seconds: time)
             viewModel.update(calroies: calroies)
@@ -460,17 +499,12 @@ extension TrackingProgressViewController: MKMapViewDelegate {
         let coordinate = Coordinate(latitude: view.annotation?.coordinate.latitude, longitude: view.annotation?.coordinate.longitude)
         guard let selectedMileStone = viewModel.mileStone(at: coordinate) else { return }
 
-        customView.photoImageView.image = UIImage(data: mileStone.imageData)
-        customView.photoImageView.backgroundColor = .boosterLabel
-        annotationView?.addSubview(customView)
-        annotationView?.centerOffset = CGPoint(x: -customView.frame.width / 2.0, y: -customView.frame.height)
-
         let mileStonePhotoViewModel = MileStonePhotoViewModel(mileStone: selectedMileStone)
         let mileStonePhotoVC = MileStonePhotoViewController(viewModel: mileStonePhotoViewModel)
         mileStonePhotoVC.delegate = self
 
         present(mileStonePhotoVC, animated: true, completion: nil)
-    }
+      }
 }
 
 extension TrackingProgressViewController: UIImagePickerControllerDelegate & UINavigationControllerDelegate {

--- a/Booster/Booster/ViewModels/TrackingProgressViewModel.swift
+++ b/Booster/Booster/ViewModels/TrackingProgressViewModel.swift
@@ -83,9 +83,23 @@ final class TrackingProgressViewModel {
     }
 
     func save(completion handler: @escaping (TrackingError?) -> Void) {
-        trackingUsecase.save(model: trackingModel.value) { error in
-            handler(error)
-        }
+        trackingUsecase.bind(handler: handler)
+        trackingUsecase.save(model: trackingModel.value)
+        trackingUsecase.save(count: Double(trackingModel.value.steps),
+                             start: trackingModel.value.startDate,
+                             end: trackingModel.value.endDate ?? Date(),
+                             quantity: .steps,
+                             unit: .count)
+        trackingUsecase.save(count: trackingModel.value.distance,
+                             start: trackingModel.value.startDate,
+                             end: trackingModel.value.endDate ?? Date(),
+                             quantity: .runing,
+                             unit: .kilometer)
+        trackingUsecase.save(count: Double(trackingModel.value.calories),
+                             start: trackingModel.value.startDate,
+                             end: trackingModel.value.endDate ?? Date(),
+                             quantity: .energy,
+                             unit: .calorie)
     }
 
     func mileStone(at coordinate: Coordinate) -> MileStone? {

--- a/Booster/Booster/Views/TrackingMapView.swift
+++ b/Booster/Booster/Views/TrackingMapView.swift
@@ -39,9 +39,9 @@ class TrackingMapView: MKMapView {
             return coordinate == mileStone.coordinate
         })
         else { return false }
-        
+
         removeAnnotation(annotation)
-        
+
         return true
     }
 


### PR DESCRIPTION
### 작업 내용
- health manager에 save 매서드 추가
- 필요한 HKQuantity, HKUnit을 Enum type으로 정의(typealias)
- tracking view controller에 메모 저장시에  Health kit에도 write하도록 변경

### 체크리스트
- [x] 메모 저장 할 때 Health Kit에 데이터 저장하기

### 구현 설명
- health manager에 save 매서드 추가
save method를 만들었습니다.
argument는 총 5개가 들어갑니다(양, 시작날짜, 이후 날짜, HealthQuantityType(enum), HealthUnit(enum)
총 3가지 정보를 저장가능합니다(거리, 발걸음 수, 칼로리)
- 필요한 HKQuantity, HKUnit을 Enum type으로 정의(typealias)
health manager에서 저장에 필요한 type과 unit을 enum으로 정의하였습니다.
외부에서 사용하기 편리하도록 typealias로 외부에 정의 하였습니다.
- tracking view controller에 메모 저장시에  Health kit에도 write하도록 변경
기존에 저장하는 부분에서 core data에만 저장하지 않고 건강앱에도 저장가능해도록 처리하였고 권한 같은경우, healthkit 권한이 있으면 바로 저장 가능하지만 아닐경우는 권한을 얻은 이후 권한 요청 결과에 따라 저장하도록 처리하였습니다.

### 하고싶은 말
코드 짠시간 보다 생각하는 시간이 길어지네요 ㅠㅠ