### PR TITLE
[D-63] 이동 경로를 나타낸다

### DIFF
--- a/Booster/Booster/ViewControllers/MileStonePhotoViewController.swift
+++ b/Booster/Booster/ViewControllers/MileStonePhotoViewController.swift
@@ -19,6 +19,7 @@ class MileStonePhotoViewController: UIViewController {
     // MARK: - Variables
     weak var delegate: MileStonePhotoViewControllerDelegate?
     private var mileStonePhotoViewModel: MileStonePhotoViewModel?
+
     private lazy var mileStonePhotoImageView: UIImageView = {
         let imageView = UIImageView(frame: CGRect(x: 0, y: 0, width: view.frame.width, height: view.frame.height))
         imageView.image = UIImage(data: mileStonePhotoViewModel?.mileStone.imageData ?? Data())?.withTintColor(.white)
@@ -55,7 +56,6 @@ class MileStonePhotoViewController: UIViewController {
 
         layoutConfig()
     }
-
     // MARK: - @IBActions
 
     // MARK: - @objc
@@ -64,11 +64,6 @@ class MileStonePhotoViewController: UIViewController {
         guard let mileStone = mileStonePhotoViewModel?.mileStone else { return }
         dismiss(animated: true, completion: nil)
         delegate?.delete(mileStone: mileStone)
-    }
-
-    @objc
-    private func didTapBackButton(_ sender: Any?) {
-        navigationController?.popViewController(animated: true)
     }
 
     // MARK: - functions

--- a/Booster/Booster/ViewControllers/Tracking/TrackingProgressViewController.swift
+++ b/Booster/Booster/ViewControllers/Tracking/TrackingProgressViewController.swift
@@ -416,6 +416,14 @@ extension TrackingProgressViewController: CLLocationManagerDelegate {
 }
 
 extension TrackingProgressViewController: MKMapViewDelegate {
+//    private class WhiteBackgroundOverlayRenderer: MKOverlayRenderer {
+//        override func draw(_ mapRect: MKMapRect, zoomScale: MKZoomScale, in context: CGContext) {
+//            let drawRect = self.rect(for: mapRect)
+//            context.setFillColor(red: 1, green: 1, blue: 1, alpha: 1.0)
+//            context.fill(drawRect)
+//        }
+//    }
+
     func mapView(_ mapView: MKMapView, rendererFor overlay: MKOverlay) -> MKOverlayRenderer {
         if let overlay = overlay as? MKCircle {
             let circleRenderer = CircleRenderer(circle: overlay)
@@ -433,11 +441,11 @@ extension TrackingProgressViewController: MKMapViewDelegate {
 
         return MKOverlayRenderer()
     }
-    
+
     func mapView(_ mapView: MKMapView, didAdd views: [MKAnnotationView]) {
         mapView.view(for: mapView.userLocation)?.isEnabled = false
     }
-    
+
     func mapView(_ mapView: MKMapView, viewFor annotation: MKAnnotation) -> MKAnnotationView? {
         if annotation is MKUserLocation { return nil }
 
@@ -449,7 +457,7 @@ extension TrackingProgressViewController: MKMapViewDelegate {
             guard let customView = UINib(nibName: NibName.photoAnnotationView.rawValue, bundle: nil).instantiate(withOwner: self, options: nil).first as? PhotoAnnotationView,
                   let mileStone = viewModel.milestones.value.last
             else { return nil }
-            
+
             customView.frame.origin.x = customView.frame.origin.x - customView.frame.width / 2.0
             customView.frame.origin.y = customView.frame.origin.y - customView.frame.height
             annotationView!.frame.origin.x = annotationView!.frame.origin.x - customView.frame.width / 2.0
@@ -474,7 +482,7 @@ extension TrackingProgressViewController: MKMapViewDelegate {
         guard let selectedMileStone = viewModel.mileStone(at: coordinate) else { return }
 
         let mileStonePhotoViewModel = MileStonePhotoViewModel(mileStone: selectedMileStone)
-        let mileStonePhotoVC = MileStonePhotoViewController(viewModel: mileStonePhotoViewModel)
+        let mileStonePhotoVC = MileStonePhotoViewController(viewModel: mileStonePhotoViewModel, testViewModel: viewModel, mapView: self.mapView)
         mileStonePhotoVC.delegate = self
 
         present(mileStonePhotoVC, animated: true, completion: nil)

--- a/Booster/Booster/ViewControllers/Tracking/TrackingProgressViewController.swift
+++ b/Booster/Booster/ViewControllers/Tracking/TrackingProgressViewController.swift
@@ -416,14 +416,6 @@ extension TrackingProgressViewController: CLLocationManagerDelegate {
 }
 
 extension TrackingProgressViewController: MKMapViewDelegate {
-//    private class WhiteBackgroundOverlayRenderer: MKOverlayRenderer {
-//        override func draw(_ mapRect: MKMapRect, zoomScale: MKZoomScale, in context: CGContext) {
-//            let drawRect = self.rect(for: mapRect)
-//            context.setFillColor(red: 1, green: 1, blue: 1, alpha: 1.0)
-//            context.fill(drawRect)
-//        }
-//    }
-
     func mapView(_ mapView: MKMapView, rendererFor overlay: MKOverlay) -> MKOverlayRenderer {
         if let overlay = overlay as? MKCircle {
             let circleRenderer = CircleRenderer(circle: overlay)

--- a/Booster/Booster/ViewModels/TrackingProgressViewModel.swift
+++ b/Booster/Booster/ViewModels/TrackingProgressViewModel.swift
@@ -106,6 +106,31 @@ final class TrackingProgressViewModel {
         return false
     }
 
+    func centerCoordinateOfPath() -> CLLocationCoordinate2D? {
+        guard let startCoordinate = startCoordinate(),
+              let startLat = startCoordinate.latitude,
+              let startLong = startCoordinate.longitude
+        else { return nil }
+        var maxLat: Double = startLat
+        var minLat: Double = startLat
+        var maxLong: Double = startLong
+        var minLong: Double = startLong
+
+        trackingModel.value.coordinates.forEach { (coordinate) in
+            guard let latValue = coordinate.latitude,
+                  let longValue = coordinate.longitude
+            else { return }
+            if maxLat < latValue { maxLat = latValue } else if minLat > latValue { minLat = latValue }
+
+            if maxLong < longValue { maxLong = longValue } else if minLong > longValue { minLong = longValue}
+        }
+
+        let midLat = (maxLat + minLat) / 2.0
+        let midLong = (maxLong + minLong) / 2.0
+
+        return CLLocationCoordinate2D(latitude: midLat, longitude: midLong)
+    }
+
     func remove(of mileStone: MileStone) -> MileStone? {
         guard let index = milestones.value.firstIndex(of: mileStone) else { return nil }
         return milestones.value.remove(at: index)


### PR DESCRIPTION
### 작업 내용
Coordinate 배열을 바탕으로 해당 Mapkit에서 이동 경로를 UIImage로 변환
### 체크리스트
- [x] Coordinate 배열을 바탕으로 해당 Mapkit에서 이동 경로를 UIImage로 변환

### 구현 설명
MKMapViewSnapShotter를 이용하여 Mapkit의 snapshot을 가져오고, 흰색의 ImageContext를 생성하여 해당 Context 위에 경로를 그려준다.

### 하고싶은 말
