### PR TITLE
[D-63] 이동 경로를 나타낸다

### DIFF
--- a/Booster/Booster/ViewControllers/Tracking/TrackingProgressViewController.swift
+++ b/Booster/Booster/ViewControllers/Tracking/TrackingProgressViewController.swift
@@ -467,7 +467,7 @@ class TrackingProgressViewController: UIViewController, BaseViewControllerTempla
             let coordinates = viewModel.coordinates()
             mapView.snapShotImageOfPath(coordinates: coordinates, center: centerCoordinate) { [weak self] (image) in
                 if let imageData = image?.pngData() {
-                    self?.viewModel.addTrackingPathImage(data: imageData)
+                    self?.viewModel.update(imageData: imageData)
                 }
             }
         }

--- a/Booster/Booster/ViewModels/Tracking/TrackingProgressViewModel.swift
+++ b/Booster/Booster/ViewModels/Tracking/TrackingProgressViewModel.swift
@@ -22,10 +22,6 @@ final class TrackingProgressViewModel {
         state = .start
     }
 
-    func addTrackingPathImage(data: Data) {
-        trackingModel.value.imageData = data
-    }
-
     func append(coordinate: Coordinate) {
         trackingModel.value.coordinates.append(coordinate)
     }
@@ -168,9 +164,5 @@ final class TrackingProgressViewModel {
         else { return nil }
 
         return milestones.value.remove(at: index)
-    }
-
-    func coordinates() -> [Coordinate] {
-        return trackingModel.value.coordinates
     }
 }


### PR DESCRIPTION
### 작업 내용
- Coordinate 배열을 기반으로 UIImage에 그려내어 CoreData에 저장
- CoreData에 저장된 UIImage를 피드 리스트 화면에 보여줌
### 체크리스트
- [x] MKSnapShotter를 이용하여 경로를 UIImage에 그려내기
- [x] 트래킹 일시 중지 시 트래킹 경로가 제대로 나타내어지지 않는 부분 수정
- [x] CoreData에 경로를 나타낸 결과 UIImage를 Data 형식으로 저장  

### 구현 설명
TrackingMapView(MKMapView)의 MKSnapShotter를 이용하면 현재 MapKit을 바탕으로 스냅샷이 형성됩니다.
이 때 옵션으로 지도의 중심과 위,경도의 범위를 지정하고 해당 범위의 지도를 어떤 크기로 그려낼건지 지정합니다.
MKSnapShot에서 point라는 메소드를 통하여 위,경도를 파라미터로 받아 스냅샷에 대한 CGPoint를 얻을 수 있습니다.
해당 CGPoint를 이용하여 UIGraphicsImageContext를 통하여 경로를 그립니다.

### 하고싶은 말
