### PR TITLE
[B-45] 이동 경로에 gradient 색 입히기 - close #67

### DIFF
--- a/Booster/Booster/Extensions/UIColor+Extension.swift
+++ b/Booster/Booster/Extensions/UIColor+Extension.swift
@@ -17,6 +17,18 @@ extension UIColor {
         )
     }
 
+    var redValue: CGFloat {
+        return CIColor(color: self).red
+    }
+
+    var greenValue: CGFloat {
+        return CIColor(color: self).green
+    }
+
+    var blueValue: CGFloat {
+        return CIColor(color: self).blue
+    }
+
     static let boosterOrange: UIColor = {
         return UIColor(named: "boosterOrange") ?? UIColor(hex: 0x0D0D0D)
     }()

--- a/Booster/Booster/Views/Tracking/TrackingMapView.swift
+++ b/Booster/Booster/Views/Tracking/TrackingMapView.swift
@@ -67,7 +67,8 @@ class TrackingMapView: MKMapView {
     }
 
     func updateUserLocationOverlay(location: CLLocation?) {
-        guard let current = location else { return }
+        guard let current = location
+        else { return }
 
         let regionRadius: CLLocationDistance = 100
         let overlayRadius: CLLocationDistance = 20
@@ -96,7 +97,9 @@ class TrackingMapView: MKMapView {
 
         let snapShotter = MKMapSnapshotter(options: options)
         snapShotter.start { [weak self] (snapshot, _) in
-            guard let snapshot = snapshot else { return }
+            guard let snapshot = snapshot
+            else { return }
+            
             let image = snapshot.image
             let pathLineWidth: CGFloat = 6
 
@@ -104,7 +107,9 @@ class TrackingMapView: MKMapView {
             color.setFill()
             UIRectFill(CGRect(origin: .zero, size: image.size))
 
-            guard let context = UIGraphicsGetCurrentContext() else { return }
+            guard let context = UIGraphicsGetCurrentContext()
+            else { return }
+            
             context.setLineWidth(pathLineWidth)
             context.setStrokeColor(UIColor.boosterOrange.cgColor)
 
@@ -173,7 +178,9 @@ class TrackingMapView: MKMapView {
                                            coordinates: [Coordinate],
                                            from fromColor: UIColor,
                                            to toColor: UIColor) -> UIColor? {
-        guard let indexOfTargetCoordinate = coordinates.firstIndex(of: coordinate) else { return nil }
+        guard let indexOfTargetCoordinate = coordinates.firstIndex(of: coordinate)
+        else { return nil }
+        
         let percentOfPathProgress = Double(indexOfTargetCoordinate) / Double(coordinates.count)
 
         let red = fromColor.redValue + ((toColor.redValue - fromColor.redValue) * percentOfPathProgress)

--- a/Booster/Booster/Views/Tracking/TrackingMapView.swift
+++ b/Booster/Booster/Views/Tracking/TrackingMapView.swift
@@ -98,13 +98,14 @@ class TrackingMapView: MKMapView {
         snapShotter.start { [weak self] (snapshot, _) in
             guard let snapshot = snapshot else { return }
             let image = snapshot.image
+            let pathLineWidth: CGFloat = 6
 
             UIGraphicsBeginImageContext(image.size)
             color.setFill()
             UIRectFill(CGRect(origin: .zero, size: image.size))
 
             guard let context = UIGraphicsGetCurrentContext() else { return }
-            context.setLineWidth(4)
+            context.setLineWidth(pathLineWidth)
             context.setStrokeColor(UIColor.boosterOrange.cgColor)
 
             var prevCoordinate: Coordinate? = self?.startCoordinate(coordinates: coordinates)
@@ -175,11 +176,11 @@ class TrackingMapView: MKMapView {
         guard let indexOfTargetCoordinate = coordinates.firstIndex(of: coordinate) else { return nil }
         let percentOfPathProgress = Double(indexOfTargetCoordinate) / Double(coordinates.count)
 
-        let r = fromColor.redValue + ((toColor.redValue - fromColor.redValue) * percentOfPathProgress)
-        let g = fromColor.greenValue + ((toColor.greenValue - fromColor.greenValue) * percentOfPathProgress)
-        let b = fromColor.blueValue + ((toColor.blueValue - fromColor.blueValue) * percentOfPathProgress)
+        let red = fromColor.redValue + ((toColor.redValue - fromColor.redValue) * percentOfPathProgress)
+        let green = fromColor.greenValue + ((toColor.greenValue - fromColor.greenValue) * percentOfPathProgress)
+        let blue = fromColor.blueValue + ((toColor.blueValue - fromColor.blueValue) * percentOfPathProgress)
 
-        return UIColor(red: r, green: g, blue: b, alpha: 1)
+        return UIColor(red: red, green: green, blue: blue, alpha: 1)
     }
 
     private func startCoordinate(coordinates: [Coordinate]) -> Coordinate? {


### PR DESCRIPTION
### 작업 내용
전체 Coordiante 배열 중 해당 Coordinate에 따른 비율을 따져 시작색과 끝색을 지정한 후 비율에 따라 gradient로 경로에 색을 입힌다

### 체크리스트
- [x] 이동 경로에 gradient 색 입히기

### 구현 설명
> 해당 구현은 모두 TrackingMapView에 존재합니다
~~~swift
private func gradientColorOfCoordinate(at coordinate: Coordinate,
                                           coordinates: [Coordinate],
                                           from fromColor: UIColor,
                                           to toColor: UIColor) -> UIColor?
~~~
해당 메소드를 통하여 전체 coordinate 배열에서 at에 해당하는 coordinate의 위치 비율(순서)를 구하여 from(시작색) 에서 to(끝색) 까지 점차 변하는 gradient 색의 비율을 구하여 해당 위치에 필요한 색을 반환합니다.

이후 path에 색을 칠해야 할 때 해당 색을 가져와서 그려주도록 합니다.

### 하고싶은 말
![스크린샷 2021-11-11 오후 2 13 19](https://user-images.githubusercontent.com/48645631/141244029-c1586a4c-02a4-42c4-a403-c127e8c481f1.png)

