### PR TITLE
[#75 #77 #78 #79 #80 #81 #84 #85] 피드 & 트래킹 부분 수정

### DIFF
--- a/Booster/Booster.xcodeproj/project.pbxproj
+++ b/Booster/Booster.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		3B31B61D27410997009D9190 /* StatisticsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA614F162733CDAA00B090D9 /* StatisticsViewModel.swift */; };
 		3B31B61E274109A5009D9190 /* Observable.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA614F3C2733CDAA00B090D9 /* Observable.swift */; };
 		3B31B61F274109AF009D9190 /* HealthStoreManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA614F532733CDAA00B090D9 /* HealthStoreManager.swift */; };
+		3B31B62127413664009D9190 /* FeedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B31B62027413664009D9190 /* FeedList.swift */; };
 		3B38FB14273A5F3B00F8620D /* TrackingCountDownView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B38FB13273A5F3B00F8620D /* TrackingCountDownView.swift */; };
 		3B38FB1A273BABBE00F8620D /* TrackingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B38FB19273BABBE00F8620D /* TrackingViewModel.swift */; };
 		3B38FB1C273BF7CD00F8620D /* FeedUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B38FB1B273BF7CD00F8620D /* FeedUseCase.swift */; };
@@ -132,6 +133,7 @@
 		3B31B5FE273CD2F7009D9190 /* Tracking+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Tracking+CoreDataProperties.swift"; sourceTree = SOURCE_ROOT; };
 		3B31B60527410470009D9190 /* TrackingProgressTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TrackingProgressTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		3B31B60727410470009D9190 /* TrackingProgressTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackingProgressTests.swift; sourceTree = "<group>"; };
+		3B31B62027413664009D9190 /* FeedList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedList.swift; sourceTree = "<group>"; };
 		3B38FB13273A5F3B00F8620D /* TrackingCountDownView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackingCountDownView.swift; sourceTree = "<group>"; };
 		3B38FB19273BABBE00F8620D /* TrackingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackingViewModel.swift; sourceTree = "<group>"; };
 		3B38FB1B273BF7CD00F8620D /* FeedUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedUseCase.swift; sourceTree = "<group>"; };
@@ -541,6 +543,7 @@
 				FA614F322733CDAA00B090D9 /* HomeData.swift */,
 				FA614F332733CDAA00B090D9 /* Coordinate.swift */,
 				FA614F362733CDAA00B090D9 /* TrackingModel.swift */,
+				3B31B62027413664009D9190 /* FeedList.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -898,6 +901,7 @@
 				FA614F6C2733CDAA00B090D9 /* Booster.xcdatamodeld in Sources */,
 				3B38FB14273A5F3B00F8620D /* TrackingCountDownView.swift in Sources */,
 				FA614F722733CDAA00B090D9 /* HomeData.swift in Sources */,
+				3B31B62127413664009D9190 /* FeedList.swift in Sources */,
 				FA614F962738F7A200B090D9 /* MileStonePhotoViewController.swift in Sources */,
 				28C96FEB27396892005BD7BC /* DetailFeedViewController.swift in Sources */,
 			);

--- a/Booster/Booster.xcodeproj/project.pbxproj
+++ b/Booster/Booster.xcodeproj/project.pbxproj
@@ -15,12 +15,27 @@
 		37852ACF273C27F100BA3D67 /* StatisticsModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37852ACE273C27F100BA3D67 /* StatisticsModelTests.swift */; };
 		37852AD6273C286D00BA3D67 /* Statistics.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA614F302733CDAA00B090D9 /* Statistics.swift */; };
 		37852AD8273C2D0B00BA3D67 /* StatisticsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37852AD7273C2D0B00BA3D67 /* StatisticsViewModelTests.swift */; };
-		37852AD9273C2FB100BA3D67 /* StatisticsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA614F162733CDAA00B090D9 /* StatisticsViewModel.swift */; };
 		379E3C57273BC182002B0B15 /* ChartView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 379E3C56273BC182002B0B15 /* ChartView.swift */; };
 		3B31B5F9273C05D8009D9190 /* FeedCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B31B5F8273C05D8009D9190 /* FeedCell.swift */; };
 		3B31B5FC273C0A66009D9190 /* CellConfigurator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B31B5FB273C0A66009D9190 /* CellConfigurator.swift */; };
 		3B31B5FF273CD2F7009D9190 /* Tracking+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B31B5FD273CD2F7009D9190 /* Tracking+CoreDataClass.swift */; };
 		3B31B600273CD2F7009D9190 /* Tracking+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B31B5FE273CD2F7009D9190 /* Tracking+CoreDataProperties.swift */; };
+		3B31B60827410470009D9190 /* TrackingProgressTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B31B60727410470009D9190 /* TrackingProgressTests.swift */; };
+		3B31B60E27410784009D9190 /* Booster.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = FA614F2A2733CDAA00B090D9 /* Booster.xcdatamodeld */; };
+		3B31B60F274107A3009D9190 /* TrackingProgressViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA614F182733CDAA00B090D9 /* TrackingProgressViewModel.swift */; };
+		3B31B610274107B4009D9190 /* MileStone.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA614F312733CDAA00B090D9 /* MileStone.swift */; };
+		3B31B611274107BA009D9190 /* Coordinate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA614F332733CDAA00B090D9 /* Coordinate.swift */; };
+		3B31B612274107BD009D9190 /* TrackingModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA614F362733CDAA00B090D9 /* TrackingModel.swift */; };
+		3B31B613274107CF009D9190 /* Tracking+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B31B5FD273CD2F7009D9190 /* Tracking+CoreDataClass.swift */; };
+		3B31B614274107D3009D9190 /* Tracking+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B31B5FE273CD2F7009D9190 /* Tracking+CoreDataProperties.swift */; };
+		3B31B61527410819009D9190 /* UserInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA614F2F2733CDAA00B090D9 /* UserInfo.swift */; };
+		3B31B616274108F3009D9190 /* Observable.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA614F3C2733CDAA00B090D9 /* Observable.swift */; };
+		3B31B61827410935009D9190 /* TrackingProgressUsecase.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA614F502733CDAA00B090D9 /* TrackingProgressUsecase.swift */; };
+		3B31B61B2741097E009D9190 /* HealthStoreManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA614F532733CDAA00B090D9 /* HealthStoreManager.swift */; };
+		3B31B61C2741098C009D9190 /* RepositoryManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA614F262733CDAA00B090D9 /* RepositoryManager.swift */; };
+		3B31B61D27410997009D9190 /* StatisticsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA614F162733CDAA00B090D9 /* StatisticsViewModel.swift */; };
+		3B31B61E274109A5009D9190 /* Observable.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA614F3C2733CDAA00B090D9 /* Observable.swift */; };
+		3B31B61F274109AF009D9190 /* HealthStoreManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA614F532733CDAA00B090D9 /* HealthStoreManager.swift */; };
 		3B38FB14273A5F3B00F8620D /* TrackingCountDownView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B38FB13273A5F3B00F8620D /* TrackingCountDownView.swift */; };
 		3B38FB1A273BABBE00F8620D /* TrackingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B38FB19273BABBE00F8620D /* TrackingViewModel.swift */; };
 		3B38FB1C273BF7CD00F8620D /* FeedUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B38FB1B273BF7CD00F8620D /* FeedUseCase.swift */; };
@@ -92,6 +107,13 @@
 			remoteGlobalIDString = 3B4E3FE3272A696E00577625;
 			remoteInfo = Booster;
 		};
+		3B31B60927410470009D9190 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 3B4E3FDC272A696E00577625 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 3B4E3FE3272A696E00577625;
+			remoteInfo = Booster;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
@@ -108,6 +130,8 @@
 		3B31B5FB273C0A66009D9190 /* CellConfigurator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CellConfigurator.swift; sourceTree = "<group>"; };
 		3B31B5FD273CD2F7009D9190 /* Tracking+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Tracking+CoreDataClass.swift"; sourceTree = SOURCE_ROOT; };
 		3B31B5FE273CD2F7009D9190 /* Tracking+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Tracking+CoreDataProperties.swift"; sourceTree = SOURCE_ROOT; };
+		3B31B60527410470009D9190 /* TrackingProgressTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TrackingProgressTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		3B31B60727410470009D9190 /* TrackingProgressTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackingProgressTests.swift; sourceTree = "<group>"; };
 		3B38FB13273A5F3B00F8620D /* TrackingCountDownView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackingCountDownView.swift; sourceTree = "<group>"; };
 		3B38FB19273BABBE00F8620D /* TrackingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackingViewModel.swift; sourceTree = "<group>"; };
 		3B38FB1B273BF7CD00F8620D /* FeedUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedUseCase.swift; sourceTree = "<group>"; };
@@ -184,6 +208,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		3B31B60227410470009D9190 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		3B4E3FE1272A696E00577625 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -213,12 +244,21 @@
 			path = Configurator;
 			sourceTree = "<group>";
 		};
+		3B31B60627410470009D9190 /* TrackingProgressTests */ = {
+			isa = PBXGroup;
+			children = (
+				3B31B60727410470009D9190 /* TrackingProgressTests.swift */,
+			);
+			path = TrackingProgressTests;
+			sourceTree = "<group>";
+		};
 		3B4E3FDB272A696E00577625 = {
 			isa = PBXGroup;
 			children = (
 				3B4E4005272A6B5200577625 /* .swiftlint.yml */,
 				FA614F072733CDAA00B090D9 /* Booster */,
 				37852ACD273C27F100BA3D67 /* StatisticsTests */,
+				3B31B60627410470009D9190 /* TrackingProgressTests */,
 				3B4E3FE5272A696E00577625 /* Products */,
 				E0CC376E0FACA7149AEAB802 /* Pods */,
 				AC0BA7BBD58ED6224A335A59 /* Frameworks */,
@@ -230,6 +270,7 @@
 			children = (
 				3B4E3FE4272A696E00577625 /* Booster.app */,
 				37852ACC273C27F100BA3D67 /* StatisticsTests.xctest */,
+				3B31B60527410470009D9190 /* TrackingProgressTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -606,6 +647,24 @@
 			productReference = 37852ACC273C27F100BA3D67 /* StatisticsTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		3B31B60427410470009D9190 /* TrackingProgressTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 3B31B60D27410470009D9190 /* Build configuration list for PBXNativeTarget "TrackingProgressTests" */;
+			buildPhases = (
+				3B31B60127410470009D9190 /* Sources */,
+				3B31B60227410470009D9190 /* Frameworks */,
+				3B31B60327410470009D9190 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				3B31B60A27410470009D9190 /* PBXTargetDependency */,
+			);
+			name = TrackingProgressTests;
+			productName = TrackingProgressTests;
+			productReference = 3B31B60527410470009D9190 /* TrackingProgressTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		3B4E3FE3272A696E00577625 /* Booster */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 3B4E3FF8272A696F00577625 /* Build configuration list for PBXNativeTarget "Booster" */;
@@ -632,11 +691,15 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
-				LastSwiftUpdateCheck = 1300;
+				LastSwiftUpdateCheck = 1310;
 				LastUpgradeCheck = 1310;
 				TargetAttributes = {
 					37852ACB273C27F100BA3D67 = {
 						CreatedOnToolsVersion = 13.0;
+						TestTargetID = 3B4E3FE3272A696E00577625;
+					};
+					3B31B60427410470009D9190 = {
+						CreatedOnToolsVersion = 13.1;
 						TestTargetID = 3B4E3FE3272A696E00577625;
 					};
 					3B4E3FE3272A696E00577625 = {
@@ -659,12 +722,20 @@
 			targets = (
 				3B4E3FE3272A696E00577625 /* Booster */,
 				37852ACB273C27F100BA3D67 /* StatisticsTests */,
+				3B31B60427410470009D9190 /* TrackingProgressTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
 		37852ACA273C27F100BA3D67 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3B31B60327410470009D9190 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -746,9 +817,31 @@
 			buildActionMask = 2147483647;
 			files = (
 				37852ACF273C27F100BA3D67 /* StatisticsModelTests.swift in Sources */,
+				3B31B61F274109AF009D9190 /* HealthStoreManager.swift in Sources */,
+				3B31B61E274109A5009D9190 /* Observable.swift in Sources */,
 				37852AD8273C2D0B00BA3D67 /* StatisticsViewModelTests.swift in Sources */,
 				37852AD6273C286D00BA3D67 /* Statistics.swift in Sources */,
-				37852AD9273C2FB100BA3D67 /* StatisticsViewModel.swift in Sources */,
+				3B31B61D27410997009D9190 /* StatisticsViewModel.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3B31B60127410470009D9190 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3B31B60F274107A3009D9190 /* TrackingProgressViewModel.swift in Sources */,
+				3B31B60E27410784009D9190 /* Booster.xcdatamodeld in Sources */,
+				3B31B613274107CF009D9190 /* Tracking+CoreDataClass.swift in Sources */,
+				3B31B610274107B4009D9190 /* MileStone.swift in Sources */,
+				3B31B61827410935009D9190 /* TrackingProgressUsecase.swift in Sources */,
+				3B31B60827410470009D9190 /* TrackingProgressTests.swift in Sources */,
+				3B31B61C2741098C009D9190 /* RepositoryManager.swift in Sources */,
+				3B31B612274107BD009D9190 /* TrackingModel.swift in Sources */,
+				3B31B61B2741097E009D9190 /* HealthStoreManager.swift in Sources */,
+				3B31B616274108F3009D9190 /* Observable.swift in Sources */,
+				3B31B614274107D3009D9190 /* Tracking+CoreDataProperties.swift in Sources */,
+				3B31B61527410819009D9190 /* UserInfo.swift in Sources */,
+				3B31B611274107BA009D9190 /* Coordinate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -818,6 +911,11 @@
 			target = 3B4E3FE3272A696E00577625 /* Booster */;
 			targetProxy = 37852AD0273C27F100BA3D67 /* PBXContainerItemProxy */;
 		};
+		3B31B60A27410470009D9190 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 3B4E3FE3272A696E00577625 /* Booster */;
+			targetProxy = 3B31B60927410470009D9190 /* PBXContainerItemProxy */;
+		};
 /* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
@@ -880,6 +978,54 @@
 				);
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = levenshtein.StatisticsTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Booster.app/Booster";
+			};
+			name = Release;
+		};
+		3B31B60B27410470009D9190 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = B3PWYBKFUK;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.Gegul.TrackingProgressTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Booster.app/Booster";
+			};
+			name = Debug;
+		};
+		3B31B60C27410470009D9190 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = B3PWYBKFUK;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.Gegul.TrackingProgressTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 5.0;
@@ -1092,6 +1238,15 @@
 			buildConfigurations = (
 				37852AD3273C27F100BA3D67 /* Debug */,
 				37852AD4273C27F100BA3D67 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		3B31B60D27410470009D9190 /* Build configuration list for PBXNativeTarget "TrackingProgressTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				3B31B60B27410470009D9190 /* Debug */,
+				3B31B60C27410470009D9190 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Booster/Booster/Models/Coordinate.swift
+++ b/Booster/Booster/Models/Coordinate.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public final class Coordinate: NSObject, NSCoding {
+final class Coordinate: NSObject, NSCoding {
     var latitude: Double?
     var longitude: Double?
 

--- a/Booster/Booster/Models/FeedList.swift
+++ b/Booster/Booster/Models/FeedList.swift
@@ -1,0 +1,16 @@
+//
+//  FeedList.swift
+//  Booster
+//
+//  Created by 김태훈 on 2021/11/14.
+//
+
+import Foundation
+
+struct FeedList {
+    var startDate: Date
+    var steps: Int
+    var distance: Double
+    var title: String
+    var imageData: Data
+}

--- a/Booster/Booster/Models/MileStone.swift
+++ b/Booster/Booster/Models/MileStone.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public final class MileStone: NSObject, NSCoding {
+final class MileStone: NSObject, NSCoding {
     var coordinate: Coordinate
     var imageData: Data
 

--- a/Booster/Booster/Models/UserInfo.swift
+++ b/Booster/Booster/Models/UserInfo.swift
@@ -7,7 +7,7 @@ struct UserInfo {
     let height: Int
     let weight: Int
 
-    init(age: Int = 0, nickname: String = "", gender: String = "", height: Int = 0, weight: Int = 0) {
+    init(age: Int = 25, nickname: String = "", gender: String = "M", height: Int = 170, weight: Int = 60) {
         self.age = age
         self.nickname = nickname
         self.gender = gender

--- a/Booster/Booster/Repositories/RepositoryManager.swift
+++ b/Booster/Booster/Repositories/RepositoryManager.swift
@@ -27,9 +27,8 @@ final class RepositoryManager {
             else { return }
 
             let entityObject = NSManagedObject(entity: entity, insertInto: self.container.viewContext)
-            value.forEach {
-                entityObject.setValue($0.value, forKey: $0.key)
-            }
+            value.forEach { entityObject.setValue($0.value, forKey: $0.key) }
+
             let context = self.container.viewContext
 
             do {
@@ -41,12 +40,32 @@ final class RepositoryManager {
         }
     }
 
+    func save<DataType: NSManagedObject>(value: [String: Any],
+              type name: String,
+              predicate: NSPredicate,
+              completion handler: @escaping (Result<DataType, Error>) -> Void) {
+        backgroundContext.perform { [weak self] in
+            guard let self = self
+            else { return }
+
+            let request = NSFetchRequest<DataType>.init(entityName: name)
+            request.predicate = predicate
+
+            do {
+                let objects = try self.container.viewContext.fetch(request)
+                value.forEach { objects[0].setValue($0.value, forKey: $0.key) }
+                try self.container.viewContext.save()
+                handler(.success(objects[0]))
+            } catch let error {
+                handler(.failure(error))
+            }
+        }
+    }
+
     func fetch<DataType: NSManagedObject>(completion handler: @escaping (Result<[DataType], Error>) -> Void) {
         backgroundContext.perform { [weak self] in
             guard let self = self
-            else {
-                return
-            }
+            else { return }
 
             do {
                 let context = try self.container.viewContext.fetch(DataType.fetchRequest())
@@ -54,6 +73,62 @@ final class RepositoryManager {
                 else { return }
 
                 handler(.success(context))
+            } catch let error {
+                handler(.failure(error))
+            }
+        }
+    }
+
+    func fetch<DataType: NSManagedObject>(entityName: String,
+                                          predicate: NSPredicate,
+                                          completion handler: @escaping (Result<[DataType], Error>) -> Void) {
+        backgroundContext.perform { [weak self] in
+            guard let self = self
+            else { return }
+
+            let request = NSFetchRequest<DataType>.init(entityName: entityName)
+            request.predicate = predicate
+            do {
+                let result = try self.container.viewContext.fetch(request)
+                handler(.success(result))
+            } catch let error {
+                handler(.failure(error))
+            }
+        }
+    }
+
+    func delete<DataType: NSManagedObject>(entityName: String,
+                                           predicate: NSPredicate,
+                                           completion handler: @escaping (Result<DataType, Error>) -> Void) {
+        backgroundContext.perform { [weak self] in
+            guard let self = self
+            else { return }
+
+            let request = NSFetchRequest<DataType>.init(entityName: entityName)
+            request.predicate = predicate
+
+            do {
+                let objects = try self.container.viewContext.fetch(request)
+                self.container.viewContext.delete(objects[0])
+                try self.container.viewContext.save()
+                handler(.success(objects[0]))
+            } catch let error {
+                handler(.failure(error))
+            }
+        }
+    }
+
+    func delete(entityName: String, completion handler: @escaping (Result<Void, Error>) -> Void) {
+        backgroundContext.perform { [weak self] in
+            guard let self = self
+            else { return }
+
+            let request = NSFetchRequest<NSFetchRequestResult>.init(entityName: entityName)
+
+            do {
+                let delete = NSBatchDeleteRequest(fetchRequest: request)
+                try self.container.viewContext.execute(delete)
+                handler(.success(()))
             } catch let error {
                 handler(.failure(error))
             }

--- a/Booster/Booster/Repositories/RepositoryManager.swift
+++ b/Booster/Booster/Repositories/RepositoryManager.swift
@@ -10,10 +10,6 @@ final class RepositoryManager {
 
     private var entityName: String
     private var container: NSPersistentContainer
-    private lazy var backgroundContext: NSManagedObjectContext = {
-        let backgroundContext = container.newBackgroundContext()
-        return backgroundContext
-    }()
 
     func save(value: [String: Any],
               type name: String,
@@ -21,6 +17,8 @@ final class RepositoryManager {
         self.entityName = name
         guard let entity = NSEntityDescription.entity(forEntityName: entityName, in: container.viewContext)
         else { return }
+
+        let backgroundContext = container.newBackgroundContext()
 
         backgroundContext.perform { [weak self] in
             guard let self = self
@@ -44,6 +42,8 @@ final class RepositoryManager {
               type name: String,
               predicate: NSPredicate,
               completion handler: @escaping (Result<DataType, Error>) -> Void) {
+        let backgroundContext = container.newBackgroundContext()
+
         backgroundContext.perform { [weak self] in
             guard let self = self
             else { return }
@@ -63,6 +63,8 @@ final class RepositoryManager {
     }
 
     func fetch<DataType: NSManagedObject>(completion handler: @escaping (Result<[DataType], Error>) -> Void) {
+        let backgroundContext = container.newBackgroundContext()
+
         backgroundContext.perform { [weak self] in
             guard let self = self
             else { return }
@@ -82,6 +84,8 @@ final class RepositoryManager {
     func fetch<DataType: NSManagedObject>(entityName: String,
                                           predicate: NSPredicate,
                                           completion handler: @escaping (Result<[DataType], Error>) -> Void) {
+        let backgroundContext = container.newBackgroundContext()
+
         backgroundContext.perform { [weak self] in
             guard let self = self
             else { return }
@@ -100,6 +104,8 @@ final class RepositoryManager {
     func delete<DataType: NSManagedObject>(entityName: String,
                                            predicate: NSPredicate,
                                            completion handler: @escaping (Result<DataType, Error>) -> Void) {
+        let backgroundContext = container.newBackgroundContext()
+
         backgroundContext.perform { [weak self] in
             guard let self = self
             else { return }
@@ -119,6 +125,8 @@ final class RepositoryManager {
     }
 
     func delete(entityName: String, completion handler: @escaping (Result<Void, Error>) -> Void) {
+        let backgroundContext = container.newBackgroundContext()
+
         backgroundContext.perform { [weak self] in
             guard let self = self
             else { return }

--- a/Booster/Booster/Services/HealthStoreManager.swift
+++ b/Booster/Booster/Services/HealthStoreManager.swift
@@ -30,7 +30,7 @@ final class HealthStoreManager {
             switch self {
             case .count: return .count()
             case .kilometer: return .meterUnit(with: .kilo)
-            case .calorie: return .largeCalorie()
+            case .calorie: return .kilocalorie()
             }
         }
     }

--- a/Booster/Booster/Usecases/DetailFeedUsecase.swift
+++ b/Booster/Booster/Usecases/DetailFeedUsecase.swift
@@ -9,13 +9,8 @@ import Foundation
 import CoreData
 
 final class DetailFeedUsecase {
-    private let entityName: String
-    private let repository: RepositoryManager
-
-    init() {
-        entityName = "Tracking"
-        self.repository = RepositoryManager()
-    }
+    private let entityName: String = "Tracking"
+    private let repository: RepositoryManager = RepositoryManager()
 
     func fetch(predicate: NSPredicate, completion handler: @escaping ([TrackingModel]) -> Void) {
         repository.fetch(entityName: entityName, predicate: predicate) { (response: Result<[Tracking], Error>) in

--- a/Booster/Booster/Usecases/DetailFeedUsecase.swift
+++ b/Booster/Booster/Usecases/DetailFeedUsecase.swift
@@ -9,15 +9,54 @@ import Foundation
 import CoreData
 
 final class DetailFeedUsecase {
+    private let entityName: String
     private let repository: RepositoryManager
 
-    init(repository: RepositoryManager) {
-        self.repository = repository
+    init() {
+        entityName = "Tracking"
+        self.repository = RepositoryManager()
     }
 
-    func execute(completion: @escaping (Result<[Tracking], Error>) -> Void) {
-        repository.fetch { (response: Result<[Tracking], Error>) in
-            completion(response)
+    func fetch(predicate: NSPredicate, completion handler: @escaping ([TrackingModel]) -> Void) {
+        repository.fetch(entityName: entityName, predicate: predicate) { (response: Result<[Tracking], Error>) in
+            switch response {
+            case .success(let result):
+                var trackingModels: [TrackingModel] = []
+                result.forEach { [weak self] value in
+                    if let trackingModel = self?.convert(tracking: value) {
+                        trackingModels.append(trackingModel)
+                    }
+                }
+                handler(trackingModels)
+            case .failure:
+                handler([])
+            }
         }
+    }
+
+    private func convert(tracking: Tracking) -> TrackingModel? {
+        if let startDate = tracking.startDate,
+           let coordinatesData = tracking.coordinates,
+           let milestonesData = tracking.milestones,
+           let coordinates = try? NSKeyedUnarchiver.unarchiveTopLevelObjectWithData(coordinatesData) as? [Coordinate],
+           let milestones = try? NSKeyedUnarchiver.unarchiveTopLevelObjectWithData(milestonesData) as? [MileStone],
+           let title = tracking.title,
+           let content = tracking.content,
+           let imageData = tracking.imageData,
+           let endDate = tracking.endDate {
+            let trackingModel = TrackingModel(startDate: startDate,
+                                              endDate: endDate,
+                                              steps: Int(tracking.steps),
+                                              calories: Int(tracking.calories),
+                                              seconds: Int(tracking.seconds),
+                                              distance: tracking.distance,
+                                              coordinates: coordinates,
+                                              milestones: milestones,
+                                              title: title,
+                                              content: content,
+                                              imageData: imageData)
+            return trackingModel
+        }
+        return nil
     }
 }

--- a/Booster/Booster/Usecases/FeedUseCase.swift
+++ b/Booster/Booster/Usecases/FeedUseCase.swift
@@ -16,62 +16,50 @@ class FeedUseCase {
         repository = RepositoryManager()
     }
 
-    func fetch(completion handler: @escaping ([TrackingModel]) -> Void) {
+    func fetch(completion handler: @escaping ([FeedList]) -> Void) {
         repository.fetch { (response: Result<[Tracking], Error>) in
             switch response {
             case .success(let result):
-                var trackingModels: [TrackingModel] = []
+                var feedLists: [FeedList] = []
                 result.forEach { [weak self] value in
-                    if let trackingModel = self?.convert(tracking: value) {
-                        trackingModels.append(trackingModel)
+                    if let feedList = self?.convert(tracking: value) {
+                        feedLists.append(feedList)
                     }
                 }
-                handler(trackingModels)
+                handler(feedLists)
             case .failure:
                 handler([])
             }
         }
     }
 
-    func fetch(predicate: NSPredicate, completion handler: @escaping ([TrackingModel]) -> Void) {
+    func fetch(predicate: NSPredicate, completion handler: @escaping ([FeedList]) -> Void) {
         repository.fetch(entityName: entity, predicate: predicate) { (response: Result<[Tracking], Error>) in
             switch response {
             case .success(let result):
-                var trackingModels: [TrackingModel] = []
+                var feedLists: [FeedList] = []
                 result.forEach { [weak self] value in
-                    if let trackingModel = self?.convert(tracking: value) {
-                        trackingModels.append(trackingModel)
+                    if let feedList = self?.convert(tracking: value) {
+                        feedLists.append(feedList)
                     }
                 }
-                handler(trackingModels)
+                handler(feedLists)
             case .failure:
                 handler([])
             }
         }
     }
 
-    private func convert(tracking: Tracking) -> TrackingModel? {
+    private func convert(tracking: Tracking) -> FeedList? {
         if let startDate = tracking.startDate,
-           let coordinatesData = tracking.coordinates,
-           let milestonesData = tracking.milestones,
-           let coordinates = try? NSKeyedUnarchiver.unarchiveTopLevelObjectWithData(coordinatesData) as? [Coordinate],
-           let milestones = try? NSKeyedUnarchiver.unarchiveTopLevelObjectWithData(milestonesData) as? [MileStone],
            let title = tracking.title,
-           let content = tracking.content,
-           let imageData = tracking.imageData,
-           let endDate = tracking.endDate {
-            let trackingModel = TrackingModel(startDate: startDate,
-                                              endDate: endDate,
-                                              steps: Int(tracking.steps),
-                                              calories: Int(tracking.calories),
-                                              seconds: Int(tracking.seconds),
-                                              distance: tracking.distance,
-                                              coordinates: coordinates,
-                                              milestones: milestones,
-                                              title: title,
-                                              content: content,
-                                              imageData: imageData)
-            return trackingModel
+           let imageData = tracking.imageData {
+            let feedList = FeedList(startDate: startDate,
+                                    steps: Int(tracking.steps),
+                                    distance: tracking.distance,
+                                    title: title,
+                                    imageData: imageData)
+            return feedList
         }
         return nil
     }

--- a/Booster/Booster/Usecases/TrackingProgressUsecase.swift
+++ b/Booster/Booster/Usecases/TrackingProgressUsecase.swift
@@ -3,10 +3,14 @@ import Foundation
 typealias TrackingError = TrackingProgressUsecase.TrackingError
 
 final class TrackingProgressUsecase {
-    enum TrackingError: Error {
+    enum TrackingError: Error, Equatable {
         case countError
         case modelError
         case error(Error)
+
+        static func == (lhs: TrackingProgressUsecase.TrackingError, rhs: TrackingProgressUsecase.TrackingError) -> Bool {
+            return lhs.localizedDescription == lhs.localizedDescription
+        }
     }
 
     private enum CoreDataKeys {

--- a/Booster/Booster/ViewControllers/Feed/FeedViewController.swift
+++ b/Booster/Booster/ViewControllers/Feed/FeedViewController.swift
@@ -43,13 +43,16 @@ final class FeedViewController: UIViewController, BaseViewControllerTemplate {
     }
 
     func configure() {
-        viewModel.trackingRecords.bind { [weak self] _ in
-            guard let self = self
-            else { return }
+        viewModel.trackingRecords.bind {  _ in
 
-            DispatchQueue.main.async {
-                self.collectionView.reloadData()
+            DispatchQueue.main.async { [weak self] in
+                guard let self = self
+                else { return }
+
                 self.refershControl.endRefreshing()
+                self.collectionView.performBatchUpdates {
+                    self.collectionView.reloadData()
+                }
             }
         }
 
@@ -102,7 +105,7 @@ extension FeedViewController: UIScrollViewDelegate {
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
         let contentY = scrollView.contentOffset.y
         let contentHeight = scrollView.contentSize.height
-        
+
         if contentY > contentHeight - scrollView.frame.height {
             viewModel.fetch()
         }

--- a/Booster/Booster/ViewControllers/Feed/FeedViewController.swift
+++ b/Booster/Booster/ViewControllers/Feed/FeedViewController.swift
@@ -115,6 +115,6 @@ extension FeedViewController: UIScrollViewDelegate {
 // MARK: - detail feed model delegate
 extension FeedViewController: DetailFeedModelDelegate {
     func detailFeed(viewModel: DetailFeedViewModel) {
-        viewModel.update(model: self.viewModel.selected())
+        viewModel.update(start: self.viewModel.selected())
     }
 }

--- a/Booster/Booster/ViewControllers/Tracking/TrackingProgressViewController.swift
+++ b/Booster/Booster/ViewControllers/Tracking/TrackingProgressViewController.swift
@@ -166,7 +166,6 @@ class TrackingProgressViewController: UIViewController, BaseViewControllerTempla
         var isMoved = true
         let timerTime = -Int(timerDate.timeIntervalSinceNow)
         let time = timerTime + lastestTime
-        let calroies = Int(60 / 15 * 0.9 * Double((time / 60) % 60))
         let limit: Double = 300
 
         pedometer.queryPedometerData(from: Date(timeIntervalSinceNow: -limit), to: Date()) { data, _ in
@@ -178,7 +177,6 @@ class TrackingProgressViewController: UIViewController, BaseViewControllerTempla
         switch isMoved && timerTime <= Int(limit) {
         case true:
             viewModel.update(seconds: time)
-            viewModel.update(calroies: calroies)
         case false:
             viewModel.toggle()
             update()
@@ -411,7 +409,7 @@ class TrackingProgressViewController: UIViewController, BaseViewControllerTempla
 
     private func makeTimerText(time: Int) -> String {
         let seconds = time % 60
-        let minutes = (time / 60) % 60
+        let minutes = (time / 60)
         var text = ""
         text += "\(minutes < 10 ? "0\(minutes)'" : "\(minutes)'")"
         text += "\(seconds < 10 ? "0\(seconds)\"\n" : "\(seconds)\"\n")"

--- a/Booster/Booster/ViewControllers/Tracking/TrackingProgressViewController.swift
+++ b/Booster/Booster/ViewControllers/Tracking/TrackingProgressViewController.swift
@@ -409,7 +409,7 @@ class TrackingProgressViewController: UIViewController, BaseViewControllerTempla
 
     private func makeTimerText(time: Int) -> String {
         let seconds = time % 60
-        let minutes = (time / 60)
+        let minutes = time / 60
         var text = ""
         text += "\(minutes < 10 ? "0\(minutes)'" : "\(minutes)'")"
         text += "\(seconds < 10 ? "0\(seconds)\"\n" : "\(seconds)\"\n")"

--- a/Booster/Booster/ViewModels/Feed/DetailFeedViewModel.swift
+++ b/Booster/Booster/ViewModels/Feed/DetailFeedViewModel.swift
@@ -8,11 +8,20 @@
 import Foundation
 
 final class DetailFeedViewModel {
+    private let usecase: DetailFeedUsecase
     var trackingModel: Observable<TrackingModel>
 
-    init() { trackingModel = Observable(TrackingModel()) }
+    init() {
+        trackingModel = Observable(TrackingModel())
+        usecase = DetailFeedUsecase()
+    }
 
-    func update(model: TrackingModel) {
-        trackingModel.value = model
+    func update(start date: Date) {
+        let predicate = NSPredicate(format: "startDate = %@", (date as NSDate) as CVarArg)
+        usecase.fetch(predicate: predicate) { [weak self] result in
+            if let model = result.first {
+                self?.trackingModel.value = model
+            }
+        }
     }
 }

--- a/Booster/Booster/ViewModels/Feed/FeedViewModel.swift
+++ b/Booster/Booster/ViewModels/Feed/FeedViewModel.swift
@@ -43,8 +43,8 @@ final class FeedViewModel {
         self.selectedIndex = index
     }
 
-    func selected() -> TrackingModel {
-        return trackingRecords.value[selectedIndex.row]
+    func selected() -> Date {
+        return trackingRecords.value[selectedIndex.row].startDate
     }
 
     func reset() {

--- a/Booster/Booster/ViewModels/Feed/FeedViewModel.swift
+++ b/Booster/Booster/ViewModels/Feed/FeedViewModel.swift
@@ -10,6 +10,7 @@ import Foundation
 typealias FeedCellConfigure = CollectionCellConfigurator<FeedCell, (date: Date,
                                                                     distance: Double,
                                                                     step: Int,
+                                                                    title: String,
                                                                     imageData: Data,
                                                                     isEmpty: Bool)>
 
@@ -19,11 +20,12 @@ final class FeedViewModel {
         return FeedCellConfigure(item: (date: isEmpty ? Date() : trackingRecords.value[indexPath.row].startDate,
                                         distance: isEmpty ? 0 : trackingRecords.value[indexPath.row].distance,
                                         step: isEmpty ? 0 : trackingRecords.value[indexPath.row].steps,
+                                        title: isEmpty ? "" : trackingRecords.value[indexPath.row].title,
                                         imageData: isEmpty ? Data() : trackingRecords.value[indexPath.row].imageData,
                                         isEmpty: recordCount() == 0))
     }
 
-    private(set) var trackingRecords: Observable<[TrackingModel]>
+    private(set) var trackingRecords: Observable<[FeedList]>
     private var selectedIndex: IndexPath
     private var difference: Int
     private let usecase: FeedUseCase

--- a/Booster/Booster/ViewModels/Feed/FeedViewModel.swift
+++ b/Booster/Booster/ViewModels/Feed/FeedViewModel.swift
@@ -60,7 +60,7 @@ final class FeedViewModel {
             let predicate = NSPredicate(format: "startDate <= %@", date as CVarArg)
             usecase.fetch(predicate: predicate) { [weak self] result in
                 if result.count == 0 { return }
-                
+
                 self?.asyncFetch(calendar: calendar, currentDate: currentDate)
             }
         }

--- a/Booster/Booster/ViewModels/Tracking/TrackingProgressViewModel.swift
+++ b/Booster/Booster/ViewModels/Tracking/TrackingProgressViewModel.swift
@@ -62,7 +62,7 @@ final class TrackingProgressViewModel {
         let minute = Double(seconds) / 60
         let height: Double = Double(user.height)/100 == 0 ? 1 : Double(user.height)/100
         let calroiesPerMinute = (0.035*Double(user.weight))+((pow(velocity, 2)/height)*0.029*Double(user.weight))
-        let calroies: Int = Int(minute * calroiesPerMinute)
+        let calroies: Int = Int(minute*calroiesPerMinute)
 
         trackingModel.value.seconds = seconds
         trackingModel.value.calories = calroies

--- a/Booster/Booster/ViewModels/Tracking/TrackingProgressViewModel.swift
+++ b/Booster/Booster/ViewModels/Tracking/TrackingProgressViewModel.swift
@@ -104,7 +104,7 @@ final class TrackingProgressViewModel {
                              end: trackingModel.value.endDate ?? Date(),
                              quantity: .steps,
                              unit: .count)
-        trackingUsecase.save(count: trackingModel.value.distance / 1000,
+        trackingUsecase.save(count: trackingModel.value.distance,
                              start: trackingModel.value.startDate,
                              end: trackingModel.value.endDate ?? Date(),
                              quantity: .runing,

--- a/Booster/Booster/ViewModels/Tracking/TrackingProgressViewModel.swift
+++ b/Booster/Booster/ViewModels/Tracking/TrackingProgressViewModel.swift
@@ -40,6 +40,7 @@ final class TrackingProgressViewModel {
 
     func recordEnd() {
         trackingModel.value.endDate = Date()
+        convert()
         trackingModel.value.milestones = milestones.value
         state = .end
     }
@@ -168,5 +169,13 @@ final class TrackingProgressViewModel {
 
     func distance() -> Double {
         return trackingModel.value.distance
+    }
+
+    private func convert() {
+        let meter = trackingModel.value.distance
+
+        if let kilometer = Double(String(format: "%.2f", meter/1000)) {
+            trackingModel.value.distance = kilometer
+        }
     }
 }

--- a/Booster/Booster/ViewModels/Tracking/TrackingProgressViewModel.swift
+++ b/Booster/Booster/ViewModels/Tracking/TrackingProgressViewModel.swift
@@ -58,7 +58,14 @@ final class TrackingProgressViewModel {
     }
 
     func update(seconds: Int) {
+        let velocity: Double = trackingModel.value.distance/Double(seconds)
+        let minute = Double(seconds) / 60
+        let height: Double = Double(user.height)/100
+        let calroiesPerMinute = (0.035*Double(user.weight))+((pow(velocity, 2)/height)*0.029*Double(user.weight))
+        let calroies: Int = Int(minute * calroiesPerMinute)
+
         trackingModel.value.seconds = seconds
+        trackingModel.value.calories = calroies
     }
 
     func update(steps: Int) {
@@ -67,10 +74,6 @@ final class TrackingProgressViewModel {
 
     func update(distance: Double) {
         trackingModel.value.distance += distance
-    }
-
-    func update(calroies: Int) {
-        trackingModel.value.calories = calroies
     }
 
     func toggle() {

--- a/Booster/Booster/ViewModels/Tracking/TrackingProgressViewModel.swift
+++ b/Booster/Booster/ViewModels/Tracking/TrackingProgressViewModel.swift
@@ -60,7 +60,7 @@ final class TrackingProgressViewModel {
     func update(seconds: Int) {
         let velocity: Double = trackingModel.value.distance/Double(seconds)
         let minute = Double(seconds) / 60
-        let height: Double = Double(user.height)/100
+        let height: Double = Double(user.height)/100 == 0 ? 1 : Double(user.height)/100
         let calroiesPerMinute = (0.035*Double(user.weight))+((pow(velocity, 2)/height)*0.029*Double(user.weight))
         let calroies: Int = Int(minute * calroiesPerMinute)
 

--- a/Booster/Booster/ViewModels/Tracking/TrackingProgressViewModel.swift
+++ b/Booster/Booster/ViewModels/Tracking/TrackingProgressViewModel.swift
@@ -35,7 +35,7 @@ final class TrackingProgressViewModel {
     }
 
     func appends(milestones: [MileStone]) {
-        trackingModel.value.milestones.append(contentsOf: milestones)
+        self.milestones.value.append(contentsOf: milestones)
     }
 
     func recordEnd() {

--- a/Booster/Booster/Views/Feed/FeedCell.swift
+++ b/Booster/Booster/Views/Feed/FeedCell.swift
@@ -60,7 +60,6 @@ extension FeedCell: ConfigurableCell {
         }
         let dateFormatter = DateFormatter()
         let weekdayText = "산책"
-        let distanceText = String.init(format: "%.1f", data.distance/1000)
         dateFormatter.locale = Locale(identifier: "ko_KR")
         dateFormatter.dateFormat = "yyyyMMDD"
 
@@ -68,7 +67,7 @@ extension FeedCell: ConfigurableCell {
 
         dateFormatter.dateFormat = "EEE요일 a "
 
-        distanceLabel.text = "\(distanceText)\nkm"
+        distanceLabel.text = "\(data.distance)\nkm"
         weekdayLabel.text = dateFormatter.string(from: data.date)+weekdayText
         stepLabel.text = "\(data.step)"
         pathImageView.image = UIImage(data: data.imageData)

--- a/Booster/Booster/Views/Feed/FeedCell.swift
+++ b/Booster/Booster/Views/Feed/FeedCell.swift
@@ -48,7 +48,12 @@ class FeedCell: UICollectionViewCell {
 }
 
 extension FeedCell: ConfigurableCell {
-    func configure(data: (date: Date, distance: Double, step: Int, imageData: Data, isEmpty: Bool)) {
+    func configure(data: (date: Date,
+                          distance: Double,
+                          step: Int,
+                          title: String,
+                          imageData: Data,
+                          isEmpty: Bool)) {
         if data.isEmpty {
             backgroundColor = .clear
             addSubview(emptyView)
@@ -59,18 +64,13 @@ extension FeedCell: ConfigurableCell {
             return
         }
         let dateFormatter = DateFormatter()
-        let weekdayText = "산책"
         dateFormatter.locale = Locale(identifier: "ko_KR")
         dateFormatter.dateFormat = "yyyyMMDD"
 
         dateLabel.text = dateFormatter.string(from: data.date)
-
-        dateFormatter.dateFormat = "EEE요일 a "
-
         distanceLabel.text = "\(data.distance)\nkm"
-        weekdayLabel.text = dateFormatter.string(from: data.date)+weekdayText
+        weekdayLabel.text = data.title
         stepLabel.text = "\(data.step)"
         pathImageView.image = UIImage(data: data.imageData)
-
     }
 }

--- a/Booster/Booster/Views/Tracking/TrackingCountDownView.swift
+++ b/Booster/Booster/Views/Tracking/TrackingCountDownView.swift
@@ -27,6 +27,7 @@ class TrackingCountDownView: UIView {
     private lazy var skipLabel: UILabel = {
         let label = UILabel(frame: frame)
         let text = "스크린 탭하여 카운트 다운 스킵하기"
+        label.alpha = 1
         label.text = text
         label.textAlignment = .center
         label.numberOfLines = 2
@@ -78,9 +79,11 @@ class TrackingCountDownView: UIView {
                            options: .curveEaseIn,
                            animations: {
                 self.countLabel.frame.origin.x = 0
+                self.countLabel.alpha = 0
             }, completion: { _ in
                 self.countLabel.removeFromSuperview()
                 text = "2"
+                self.countLabel.alpha = 1
                 self.countLabel.text = text
                 self.countLabel.sizeToFit()
                 self.countLabel.frame.origin = CGPoint(x: self.frame.maxX, y: self.frame.maxY/2-self.countLabel.frame.height/2)
@@ -96,8 +99,10 @@ class TrackingCountDownView: UIView {
                                    options: .curveEaseIn,
                                    animations: {
                         self.countLabel.frame.origin.x = 0
+                        self.countLabel.alpha = 0
                     }, completion: { _ in
                         self.countLabel.removeFromSuperview()
+                        self.countLabel.alpha = 1
                         text = "1"
                         self.countLabel.text = text
                         self.countLabel.sizeToFit()
@@ -114,6 +119,7 @@ class TrackingCountDownView: UIView {
                                            options: .curveEaseIn,
                                            animations: {
                                 self.countLabel.frame.origin.x = 0
+                                self.countLabel.alpha = 0
                             }, completion: { _ in
                                 self.countLabel.removeFromSuperview()
                                 self.completion?()

--- a/Booster/Booster/Views/Tracking/TrackingCountDownView.swift
+++ b/Booster/Booster/Views/Tracking/TrackingCountDownView.swift
@@ -72,6 +72,7 @@ class TrackingCountDownView: UIView {
                        delay: 0.45,
                        options: .curveEaseOut,
                        animations: {
+            self.countLabel.alpha = 1
             self.countLabel.frame.origin.x = self.frame.maxX/2-self.countLabel.frame.width/2
         }, completion: { _ in
             UIView.animate(withDuration: 0.15,
@@ -83,7 +84,6 @@ class TrackingCountDownView: UIView {
             }, completion: { _ in
                 self.countLabel.removeFromSuperview()
                 text = "2"
-                self.countLabel.alpha = 1
                 self.countLabel.text = text
                 self.countLabel.sizeToFit()
                 self.countLabel.frame.origin = CGPoint(x: self.frame.maxX, y: self.frame.maxY/2-self.countLabel.frame.height/2)
@@ -92,6 +92,7 @@ class TrackingCountDownView: UIView {
                                delay: 0,
                                options: .curveEaseOut,
                                animations: {
+                    self.countLabel.alpha = 1
                     self.countLabel.frame.origin.x = self.frame.maxX/2-self.countLabel.frame.width/2
                 }, completion: { _ in
                     UIView.animate(withDuration: 0.15,
@@ -102,7 +103,6 @@ class TrackingCountDownView: UIView {
                         self.countLabel.alpha = 0
                     }, completion: { _ in
                         self.countLabel.removeFromSuperview()
-                        self.countLabel.alpha = 1
                         text = "1"
                         self.countLabel.text = text
                         self.countLabel.sizeToFit()
@@ -112,6 +112,7 @@ class TrackingCountDownView: UIView {
                                        delay: 0,
                                        options: .curveEaseOut,
                                        animations: {
+                            self.countLabel.alpha = 1
                             self.countLabel.frame.origin.x = self.frame.maxX/2-self.countLabel.frame.width/2
                         }, completion: { _ in
                             UIView.animate(withDuration: 0.15,

--- a/Booster/StatisticsTests/StatisticsModelTests.swift
+++ b/Booster/StatisticsTests/StatisticsModelTests.swift
@@ -99,5 +99,4 @@ final class StatisticsModelTests: XCTestCase {
         // then
         XCTAssertEqual(averageStep, resultAverageStep)
     }
-
 }

--- a/Booster/TrackingProgressTests/TrackingProgressTests.swift
+++ b/Booster/TrackingProgressTests/TrackingProgressTests.swift
@@ -1,0 +1,243 @@
+//
+//  TrackingProgressTests.swift
+//  TrackingProgressTests
+//
+//  Created by 김태훈 on 2021/11/14.
+//
+
+import XCTest
+import CoreLocation
+
+class TrackingProgressTests: XCTestCase {
+    var trackingProgressViewModel: TrackingProgressViewModel!
+
+    override func setUpWithError() throws {
+        trackingProgressViewModel = TrackingProgressViewModel(trackingModel: TrackingModel(), user: UserInfo())
+    }
+
+    override func tearDownWithError() throws {
+        trackingProgressViewModel = nil
+    }
+
+    func test좌표추가() throws {
+        // given
+        let coordinate = Coordinate(latitude: nil, longitude: nil)
+
+        // when
+        trackingProgressViewModel.append(coordinate: coordinate)
+
+        // then
+        XCTAssertEqual(trackingProgressViewModel.trackingModel.value.coordinates.count, 1, "좌표가 추가되지 않았습니다.")
+    }
+
+    func test마일스톤추가() throws {
+        // given
+        let milestone = MileStone(latitude: 0, longitude: 0, imageData: Data())
+
+        // when
+        trackingProgressViewModel.append(milestone: milestone)
+
+        // then
+        XCTAssertEqual(trackingProgressViewModel.milestones.value.count, 1, "마일스톤이 추가되지 않았습니다.")
+    }
+
+    func test좌표리스트추가() throws {
+        // given
+        let coordinates = [Coordinate].init(repeating: Coordinate(latitude: nil, longitude: nil), count: 3)
+
+        // when
+        trackingProgressViewModel.appends(coordinates: coordinates)
+
+        // then
+        XCTAssertEqual(trackingProgressViewModel.trackingModel.value.coordinates.count, 3, "좌표 리스트가 추가되지 않았습니다.")
+    }
+
+    func test마일스톤리스트추가() throws {
+        // given
+        let milestones = [MileStone].init(repeating: MileStone(latitude: 0, longitude: 0, imageData: Data()), count: 3)
+
+        // when
+        trackingProgressViewModel.appends(milestones: milestones)
+
+        // then
+        XCTAssertEqual(trackingProgressViewModel.milestones.value.count, 3, "마일스톤 리스트가 추가되지 않았습니다.")
+    }
+
+    func test트래킹중일시정지토글() throws {
+        // given
+        let coordinate = Coordinate(latitude: nil, longitude: nil)
+
+        // when
+        trackingProgressViewModel.append(coordinate: coordinate)
+        trackingProgressViewModel.toggle()
+
+        // then
+        XCTAssertNil(trackingProgressViewModel.latestCoordinate()?.latitude, "일시중지 되지 않았습니다.")
+        XCTAssertNil(trackingProgressViewModel.latestCoordinate()?.longitude, "일시중지 되지 않았습니다.")
+    }
+
+    func test동일한마일스톤객체존재() throws {
+        // given
+        let milestones = [
+            MileStone(latitude: 1, longitude: 2, imageData: Data()),
+            MileStone(latitude: 2, longitude: 3, imageData: Data()),
+            MileStone(latitude: 4, longitude: 5, imageData: Data())
+        ]
+        let coordinate = Coordinate(latitude: 4, longitude: 5)
+
+        // when
+        trackingProgressViewModel.appends(milestones: milestones)
+
+        // then
+        XCTAssertNotNil(trackingProgressViewModel.mileStone(at: coordinate))
+    }
+
+    func test동일한마일스톤객체존재하지않음() throws {
+        // given
+        let milestones = [
+            MileStone(latitude: 1, longitude: 2, imageData: Data()),
+            MileStone(latitude: 2, longitude: 3, imageData: Data()),
+            MileStone(latitude: 4, longitude: 5, imageData: Data())
+        ]
+        let coordinate = Coordinate(latitude: 9, longitude: 9)
+
+        // when
+        trackingProgressViewModel.appends(milestones: milestones)
+
+        // then
+        XCTAssertNil(trackingProgressViewModel.mileStone(at: coordinate))
+    }
+
+    func test해당위치에마일스톤존재() throws {
+        // given
+        let milestones = [
+            MileStone(latitude: 1, longitude: 2, imageData: Data()),
+            MileStone(latitude: 2, longitude: 3, imageData: Data()),
+            MileStone(latitude: 4, longitude: 5, imageData: Data())
+        ]
+
+        // when
+        trackingProgressViewModel.appends(milestones: milestones)
+
+        // then
+        XCTAssertTrue(trackingProgressViewModel.isMileStoneExistAt(latitude: 4, longitude: 5))
+    }
+
+    func test해당위치에마일스톤존재하지않음() throws {
+        // given
+        let milestones = [
+            MileStone(latitude: 1, longitude: 2, imageData: Data()),
+            MileStone(latitude: 2, longitude: 3, imageData: Data()),
+            MileStone(latitude: 4, longitude: 5, imageData: Data())
+        ]
+
+        // when
+        trackingProgressViewModel.appends(milestones: milestones)
+
+        // then
+        XCTAssertFalse(trackingProgressViewModel.isMileStoneExistAt(latitude: 10, longitude: 5))
+    }
+
+    func test중앙위치() throws {
+        // given
+        let coordinates = [
+            Coordinate(latitude: 0, longitude: 0),
+            Coordinate(latitude: 2, longitude: 1),
+            Coordinate(latitude: 4, longitude: 4)
+        ]
+        let result = CLLocationCoordinate2D(latitude: 2, longitude: 2)
+
+        // when
+        trackingProgressViewModel.appends(coordinates: coordinates)
+        let center = trackingProgressViewModel.centerCoordinateOfPath()
+
+        // then
+        XCTAssertEqual(result.latitude.binade, center!.latitude.binade)
+        XCTAssertEqual(result.longitude.binade, center!.longitude.binade)
+    }
+
+    func test마일스톤삭제성공() throws {
+        // given
+        let milestones = [
+            MileStone(latitude: 1, longitude: 2, imageData: Data()),
+            MileStone(latitude: 2, longitude: 3, imageData: Data()),
+            MileStone(latitude: 4, longitude: 5, imageData: Data())
+        ]
+
+        // when
+        trackingProgressViewModel.appends(milestones: milestones)
+        let remove = trackingProgressViewModel.remove(of: milestones[1])
+
+        // then
+        XCTAssertNotNil(remove)
+    }
+
+    func test마일스톤삭제실패() throws {
+        // given
+        let milestones = [
+            MileStone(latitude: 1, longitude: 2, imageData: Data()),
+            MileStone(latitude: 2, longitude: 3, imageData: Data()),
+            MileStone(latitude: 4, longitude: 5, imageData: Data())
+        ]
+        let otherMilestone = MileStone(latitude: 5, longitude: 6, imageData: Data())
+
+        // when
+        trackingProgressViewModel.appends(milestones: milestones)
+        let remove = trackingProgressViewModel.remove(of: otherMilestone)
+
+        // then
+        XCTAssertNil(remove)
+    }
+
+    func test기록종료() throws {
+        // given
+        let milestones = [
+            MileStone(latitude: 1, longitude: 2, imageData: Data()),
+            MileStone(latitude: 2, longitude: 3, imageData: Data()),
+            MileStone(latitude: 4, longitude: 5, imageData: Data())
+        ]
+
+        // when
+        trackingProgressViewModel.appends(milestones: milestones)
+        trackingProgressViewModel.recordEnd()
+
+        // then
+        XCTAssertEqual(milestones.count, trackingProgressViewModel.trackingModel.value.milestones.count)
+        XCTAssert(trackingProgressViewModel.state == .end)
+    }
+
+    func test코어데이터기록저장() throws {
+        // given
+        let milestones = [
+            MileStone(latitude: 1, longitude: 2, imageData: Data()),
+            MileStone(latitude: 2, longitude: 3, imageData: Data()),
+            MileStone(latitude: 4, longitude: 5, imageData: Data())
+        ]
+        let coordinates = [
+            Coordinate(latitude: 0, longitude: 0),
+            Coordinate(latitude: 2, longitude: 1),
+            Coordinate(latitude: 4, longitude: 4)
+        ]
+        let expectation = XCTestExpectation(description: "CoreDataSaveTaskExpactation")
+        var error: TrackingError?
+        var count: Int = 0
+
+        // when
+        trackingProgressViewModel.appends(milestones: milestones)
+        trackingProgressViewModel.appends(coordinates: coordinates)
+        trackingProgressViewModel.recordEnd()
+
+        trackingProgressViewModel.save { value in
+            count += 1
+            if let value = value, value != TrackingError.countError {
+                error = value
+            }
+
+            if count == 4 { expectation.fulfill() }
+        }
+
+        // then
+        wait(for: [expectation], timeout: 5.0)
+        XCTAssertNil(error)
+    }
+}

--- a/Booster/TrackingProgressTests/TrackingProgressTests.swift
+++ b/Booster/TrackingProgressTests/TrackingProgressTests.swift
@@ -19,7 +19,7 @@ class TrackingProgressTests: XCTestCase {
         trackingProgressViewModel = nil
     }
 
-    func test좌표추가() throws {
+    func test_좌표_추가() throws {
         // given
         let coordinate = Coordinate(latitude: nil, longitude: nil)
 
@@ -30,7 +30,7 @@ class TrackingProgressTests: XCTestCase {
         XCTAssertEqual(trackingProgressViewModel.trackingModel.value.coordinates.count, 1, "좌표가 추가되지 않았습니다.")
     }
 
-    func test마일스톤추가() throws {
+    func test_마일스톤_추가() throws {
         // given
         let milestone = MileStone(latitude: 0, longitude: 0, imageData: Data())
 
@@ -41,7 +41,7 @@ class TrackingProgressTests: XCTestCase {
         XCTAssertEqual(trackingProgressViewModel.milestones.value.count, 1, "마일스톤이 추가되지 않았습니다.")
     }
 
-    func test좌표리스트추가() throws {
+    func test_좌표_리스트_추가() throws {
         // given
         let coordinates = [Coordinate].init(repeating: Coordinate(latitude: nil, longitude: nil), count: 3)
 
@@ -52,7 +52,7 @@ class TrackingProgressTests: XCTestCase {
         XCTAssertEqual(trackingProgressViewModel.trackingModel.value.coordinates.count, 3, "좌표 리스트가 추가되지 않았습니다.")
     }
 
-    func test마일스톤리스트추가() throws {
+    func test_마일스톤_리스트_추가() throws {
         // given
         let milestones = [MileStone].init(repeating: MileStone(latitude: 0, longitude: 0, imageData: Data()), count: 3)
 
@@ -63,7 +63,7 @@ class TrackingProgressTests: XCTestCase {
         XCTAssertEqual(trackingProgressViewModel.milestones.value.count, 3, "마일스톤 리스트가 추가되지 않았습니다.")
     }
 
-    func test트래킹중일시정지토글() throws {
+    func test_트래킹중_일시정지_토글() throws {
         // given
         let coordinate = Coordinate(latitude: nil, longitude: nil)
 
@@ -92,7 +92,7 @@ class TrackingProgressTests: XCTestCase {
         XCTAssertNotNil(trackingProgressViewModel.mileStone(at: coordinate))
     }
 
-    func test동일한마일스톤객체존재하지않음() throws {
+    func test_동일한_마일스톤_객체_존재_하지않음() throws {
         // given
         let milestones = [
             MileStone(latitude: 1, longitude: 2, imageData: Data()),
@@ -108,7 +108,7 @@ class TrackingProgressTests: XCTestCase {
         XCTAssertNil(trackingProgressViewModel.mileStone(at: coordinate))
     }
 
-    func test해당위치에마일스톤존재() throws {
+    func test_해당위치에_마일스톤_존재() throws {
         // given
         let milestones = [
             MileStone(latitude: 1, longitude: 2, imageData: Data()),
@@ -123,7 +123,7 @@ class TrackingProgressTests: XCTestCase {
         XCTAssertTrue(trackingProgressViewModel.isMileStoneExistAt(latitude: 4, longitude: 5))
     }
 
-    func test해당위치에마일스톤존재하지않음() throws {
+    func test_해당위치에_마일스톤_존재하지_않음() throws {
         // given
         let milestones = [
             MileStone(latitude: 1, longitude: 2, imageData: Data()),
@@ -138,7 +138,7 @@ class TrackingProgressTests: XCTestCase {
         XCTAssertFalse(trackingProgressViewModel.isMileStoneExistAt(latitude: 10, longitude: 5))
     }
 
-    func test중앙위치() throws {
+    func test_중앙_위치() throws {
         // given
         let coordinates = [
             Coordinate(latitude: 0, longitude: 0),
@@ -156,7 +156,7 @@ class TrackingProgressTests: XCTestCase {
         XCTAssertEqual(result.longitude.binade, center!.longitude.binade)
     }
 
-    func test마일스톤삭제성공() throws {
+    func test_마일스톤_삭제_성공() throws {
         // given
         let milestones = [
             MileStone(latitude: 1, longitude: 2, imageData: Data()),
@@ -172,7 +172,7 @@ class TrackingProgressTests: XCTestCase {
         XCTAssertNotNil(remove)
     }
 
-    func test마일스톤삭제실패() throws {
+    func test_마일스톤_삭제_실패() throws {
         // given
         let milestones = [
             MileStone(latitude: 1, longitude: 2, imageData: Data()),
@@ -189,7 +189,7 @@ class TrackingProgressTests: XCTestCase {
         XCTAssertNil(remove)
     }
 
-    func test기록종료() throws {
+    func test_기록종료() throws {
         // given
         let milestones = [
             MileStone(latitude: 1, longitude: 2, imageData: Data()),
@@ -206,7 +206,7 @@ class TrackingProgressTests: XCTestCase {
         XCTAssert(trackingProgressViewModel.state == .end)
     }
 
-    func test코어데이터기록저장() throws {
+    func test_코어데이터_기록_저장() throws {
         // given
         let milestones = [
             MileStone(latitude: 1, longitude: 2, imageData: Data()),


### PR DESCRIPTION
### 작업 내용
Repository Manager에 CURD 기능을 추가했습니다 기능들은 다음과 같습니다.
- 업데이트
- 삭제(일부, 전체)
- 불러오기(일부)

저장할 때 거리 단위를 meter가 아닌 km(소수점 2번째 까지)로 저장하도록 변경하였습니다.

health kit에 저장될 때 칼로리 단위를 kilo 칼로리로 변경 했습니다.

Transromable을 사용하지 않는 model은 접근 지정자 삭제

칼로리 계산공식 변경

피드 리스트 불러오기 수정(일부 불러오기로 수정)

피드 상세보기 불러오기 수정(`startDate` 받아서 불러오기)

tracking progress 뷰모델 유닛테스트

피드 리스트 제목 나오도록 수정

애니메이션 개선 작업(카운트 다운)

### 체크리스트
- [x] Repository Manager에 CURD
- [x] 저장시 거리 단위 변경
- [x] health kit 칼로리 단위 변경
- [x] 칼로리 계산공식 변경
- [x] 피드 리스트 불러오기 수정
- [x] 피드 상세보기 데이터 불러오기 수정
- [x] tracking progress 뷰모델 유닛테스트

### 구현 설명
Repository Manager에 CURD 
``` swift
func save<DataType: NSManagedObject>(value: [String: Any],
              type name: String,
              predicate: NSPredicate,
              completion handler: @escaping (Result<DataType, Error>) -> Void)
```
수정을 원하는 내용 원하는 조건 값을 넣고 type(entity)를 지정하면 업데이트를 진행하는 method 입니다.

``` swift
func fetch<DataType: NSManagedObject>(completion handler: @escaping (Result<[DataType], Error>) -> Void)
```
이 부분은 기존에 entity name을 받는 구조에서 entity name을 안 받는 것으로 수정했습니다.


``` swift
func fetch<DataType: NSManagedObject>(entityName: String,
                                          predicate: NSPredicate,
                                          completion handler: @escaping (Result<[DataType], Error>) -> Void)
```
원하는 조건 값을 넣고 type(entity)를 지정하면 조건에 맞는 데이터를 불러오는 method 입니다.

``` swift
func delete<DataType: NSManagedObject>(entityName: String,
                                           predicate: NSPredicate,
                                           completion handler: @escaping (Result<DataType, Error>) -> Void)

func delete(entityName: String, completion handler: @escaping (Result<Void, Error>) -> Void)
```
일부 삭제, 전체 삭제 입니다.

칼로리 계산 공식은 아래와 같은 수식으로 변경했습니다.
``` 
분당칼로리 = (0.035 X 몸무게(kg) ) + ((초속(m/s) ^ 2) / 신장(m) ) X (0.029) X (몸무게(kg) )

최종 칼로리 = 분당 칼로리 * 총 시간(분)
```
불러오기 시에 `NSPredicate`를 활용하여 일부 fetch 하도록 변경하였습니다.
로직은 다음과 같습니다.
1. 해당 날짜보다 이전 자료들이 있는지 조회한다.
2. 만약 자료들이 존재하면 1주일 단위로 자료들을 계속 검색한다.
3. 검색시에 자료가 존재하면 업데이트를 진행한다.
위 순서로 동작합니다.

collection view에 무한 스크롤과 같은 불러오기 매커니즘과 refresh control을 적용하였습니다.
``` swift
func update(start date: Date) {
    let predicate = NSPredicate(format: "startDate = %@", (date as NSDate) as CVarArg)
    usecase.fetch(predicate: predicate) { [weak self] result in
        if let model = result.first {
            self?.trackingModel.value = model
        }
    }
}
```
피드 상세보기에서 데이터를 불러올 때 시작 날짜를 받아 시작날짜와 동일한 데이터를 불러와서 업데이트 하도록 변경하였습니다.

### 하고싶은 말
