### PR TITLE
[#74] 홈페이지 시간별 걸음수 그래프 & usecase 추가

### DIFF
--- a/Booster/Booster.xcodeproj/project.pbxproj
+++ b/Booster/Booster.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		28C96FED27396F6B005BD7BC /* DetailFeedViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28C96FEC27396F6B005BD7BC /* DetailFeedViewModel.swift */; };
 		28C96FF3273A4634005BD7BC /* UIResponder+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28C96FF2273A4634005BD7BC /* UIResponder+Extension.swift */; };
 		28C9702D273C3041005BD7BC /* DetailFeedUsecase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28C9702C273C3041005BD7BC /* DetailFeedUsecase.swift */; };
+		28C9702F2740D731005BD7BC /* HomeUsecase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28C9702E2740D731005BD7BC /* HomeUsecase.swift */; };
 		37852ACF273C27F100BA3D67 /* StatisticsModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37852ACE273C27F100BA3D67 /* StatisticsModelTests.swift */; };
 		37852AD6273C286D00BA3D67 /* Statistics.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA614F302733CDAA00B090D9 /* Statistics.swift */; };
 		37852AD8273C2D0B00BA3D67 /* StatisticsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37852AD7273C2D0B00BA3D67 /* StatisticsViewModelTests.swift */; };
@@ -55,7 +56,7 @@
 		FA614F6F2733CDAA00B090D9 /* UserInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA614F2F2733CDAA00B090D9 /* UserInfo.swift */; };
 		FA614F702733CDAA00B090D9 /* Statistics.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA614F302733CDAA00B090D9 /* Statistics.swift */; };
 		FA614F712733CDAA00B090D9 /* MileStone.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA614F312733CDAA00B090D9 /* MileStone.swift */; };
-		FA614F722733CDAA00B090D9 /* HomeData.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA614F322733CDAA00B090D9 /* HomeData.swift */; };
+		FA614F722733CDAA00B090D9 /* HomeModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA614F322733CDAA00B090D9 /* HomeModel.swift */; };
 		FA614F732733CDAA00B090D9 /* Coordinate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA614F332733CDAA00B090D9 /* Coordinate.swift */; };
 		FA614F762733CDAA00B090D9 /* TrackingModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA614F362733CDAA00B090D9 /* TrackingModel.swift */; };
 		FA614F772733CDAA00B090D9 /* NSAttributedString+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA614F382733CDAA00B090D9 /* NSAttributedString+Extension.swift */; };
@@ -100,6 +101,7 @@
 		28C96FEC27396F6B005BD7BC /* DetailFeedViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailFeedViewModel.swift; sourceTree = "<group>"; };
 		28C96FF2273A4634005BD7BC /* UIResponder+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIResponder+Extension.swift"; sourceTree = "<group>"; };
 		28C9702C273C3041005BD7BC /* DetailFeedUsecase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailFeedUsecase.swift; sourceTree = "<group>"; };
+		28C9702E2740D731005BD7BC /* HomeUsecase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeUsecase.swift; sourceTree = "<group>"; };
 		37852ACC273C27F100BA3D67 /* StatisticsTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = StatisticsTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		37852ACE273C27F100BA3D67 /* StatisticsModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatisticsModelTests.swift; sourceTree = "<group>"; };
 		37852AD7273C2D0B00BA3D67 /* StatisticsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatisticsViewModelTests.swift; sourceTree = "<group>"; };
@@ -146,7 +148,7 @@
 		FA614F2F2733CDAA00B090D9 /* UserInfo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserInfo.swift; sourceTree = "<group>"; };
 		FA614F302733CDAA00B090D9 /* Statistics.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Statistics.swift; sourceTree = "<group>"; };
 		FA614F312733CDAA00B090D9 /* MileStone.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MileStone.swift; sourceTree = "<group>"; };
-		FA614F322733CDAA00B090D9 /* HomeData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HomeData.swift; sourceTree = "<group>"; };
+		FA614F322733CDAA00B090D9 /* HomeModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HomeModel.swift; sourceTree = "<group>"; };
 		FA614F332733CDAA00B090D9 /* Coordinate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Coordinate.swift; sourceTree = "<group>"; };
 		FA614F362733CDAA00B090D9 /* TrackingModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrackingModel.swift; sourceTree = "<group>"; };
 		FA614F382733CDAA00B090D9 /* NSAttributedString+Extension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSAttributedString+Extension.swift"; sourceTree = "<group>"; };
@@ -497,7 +499,7 @@
 				FA614F2F2733CDAA00B090D9 /* UserInfo.swift */,
 				FA614F302733CDAA00B090D9 /* Statistics.swift */,
 				FA614F312733CDAA00B090D9 /* MileStone.swift */,
-				FA614F322733CDAA00B090D9 /* HomeData.swift */,
+				FA614F322733CDAA00B090D9 /* HomeModel.swift */,
 				FA614F332733CDAA00B090D9 /* Coordinate.swift */,
 				FA614F362733CDAA00B090D9 /* TrackingModel.swift */,
 			);
@@ -573,6 +575,7 @@
 				FA614F502733CDAA00B090D9 /* TrackingProgressUsecase.swift */,
 				28C9702C273C3041005BD7BC /* DetailFeedUsecase.swift */,
 				3B38FB1B273BF7CD00F8620D /* FeedUseCase.swift */,
+				28C9702E2740D731005BD7BC /* HomeUsecase.swift */,
 			);
 			path = Usecases;
 			sourceTree = "<group>";
@@ -804,8 +807,9 @@
 				FA614F772733CDAA00B090D9 /* NSAttributedString+Extension.swift in Sources */,
 				FA614F6C2733CDAA00B090D9 /* Booster.xcdatamodeld in Sources */,
 				3B38FB14273A5F3B00F8620D /* TrackingCountDownView.swift in Sources */,
-				FA614F722733CDAA00B090D9 /* HomeData.swift in Sources */,
+				FA614F722733CDAA00B090D9 /* HomeModel.swift in Sources */,
 				FA614F962738F7A200B090D9 /* MileStonePhotoViewController.swift in Sources */,
+				28C9702F2740D731005BD7BC /* HomeUsecase.swift in Sources */,
 				28C96FEB27396892005BD7BC /* DetailFeedViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Booster/Booster/Models/HomeModel.swift
+++ b/Booster/Booster/Models/HomeModel.swift
@@ -7,13 +7,13 @@
 
 import Foundation
 
-struct HomeData {
+struct HomeModel {
     var kcal: Int
     var km: Double
     var activeTime: TimeInterval
     var goal: Int
     var totalStepCount: Int
-    var hourlyStepCount: [Int]
+    var hourlyStatistics: StatisticsCollection
 
     init() {
         kcal = 0
@@ -21,6 +21,6 @@ struct HomeData {
         activeTime = 0
         goal = 0
         totalStepCount = 0
-        hourlyStepCount = []
+        hourlyStatistics = StatisticsCollection()
     }
 }

--- a/Booster/Booster/Storyboards/Home.storyboard
+++ b/Booster/Booster/Storyboards/Home.storyboard
@@ -82,7 +82,7 @@
                                 <color key="textColor" name="boosterLabel"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="TBK-bI-lVF">
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="TBK-bI-lVF" customClass="ChartView" customModule="Booster" customModuleProvider="target">
                                 <rect key="frame" x="30" y="648" width="354" height="135"/>
                                 <color key="backgroundColor" name="boosterBackground"/>
                             </view>
@@ -118,6 +118,7 @@
                     <simulatedTabBarMetrics key="simulatedBottomBarMetrics"/>
                     <connections>
                         <outlet property="goalLabel" destination="TZn-KZ-HUf" id="TU4-Ra-AQ7"/>
+                        <outlet property="hourlyBarChartView" destination="TBK-bI-lVF" id="lkg-ka-wVa"/>
                         <outlet property="kcalLabel" destination="IOt-Vq-NdU" id="mHf-Oa-YZ3"/>
                         <outlet property="kmLabel" destination="576-pf-rBg" id="Xhi-iJ-LE1"/>
                         <outlet property="timeActiveLabel" destination="DK1-7W-5Tf" id="gcb-mb-QTF"/>

--- a/Booster/Booster/Usecases/HomeUsecase.swift
+++ b/Booster/Booster/Usecases/HomeUsecase.swift
@@ -22,8 +22,8 @@ final class HomeUsecase {
         HealthStoreManager.shared.requestStatisticsCollectionQuery(type: stepCountSampleType,
                                                                    predicate: predicate,
                                                                    interval: DateComponents(hour: 1),
-                                                                   anchorDate: anchorDate) { [weak self] result in
-            result.enumerateStatistics(from: self?.retrieveTodayStartDate(from: now) ?? now,
+                                                                   anchorDate: anchorDate) { result in
+            result.enumerateStatistics(from: Calendar.current.startOfDay(for: now),
                                        to: now,
                                        with: { statistics, _ in
                 completion(statistics)
@@ -36,7 +36,7 @@ final class HomeUsecase {
         else { return }
 
         let now = Date()
-        let start = retrieveTodayStartDate(from: now)
+        let start = Calendar.current.startOfDay(for: now)
         let predicate = HKQuery.predicateForSamples(withStart: start,
                                                     end: now,
                                                     options: .strictStartDate)
@@ -47,12 +47,8 @@ final class HomeUsecase {
     }
 
     private func createTodayPredicate(end: Date = Date()) -> NSPredicate {
-        return HKQuery.predicateForSamples(withStart: retrieveTodayStartDate(from: end),
+        return HKQuery.predicateForSamples(withStart: Calendar.current.startOfDay(for: end),
                                            end: end,
                                            options: .strictStartDate)
-    }
-
-    private func retrieveTodayStartDate(from date: Date = Date()) -> Date {
-        return Calendar.current.startOfDay(for: date)
     }
 }

--- a/Booster/Booster/Usecases/HomeUsecase.swift
+++ b/Booster/Booster/Usecases/HomeUsecase.swift
@@ -1,0 +1,58 @@
+//
+//  HomeUsecase.swift
+//  Booster
+//
+//  Created by hiju on 2021/11/14.
+//
+import Foundation
+import HealthKit
+
+final class HomeUsecase {
+    func fetchHourlyStepCountsData(completion: @escaping (HKStatistics) -> Void) {
+        guard let stepCountSampleType = HKSampleType.quantityType(forIdentifier: .stepCount),
+              let anchorDate = Calendar.current.date(bySettingHour: 0,
+                                                     minute: 0,
+                                                     second: 0,
+                                                     of: Date())
+        else { return }
+
+        let now = Date()
+        let predicate = createTodayPredicate()
+
+        HealthStoreManager.shared.requestStatisticsCollectionQuery(type: stepCountSampleType,
+                                                                   predicate: predicate,
+                                                                   interval: DateComponents(hour: 1),
+                                                                   anchorDate: anchorDate) { [weak self] result in
+            result.enumerateStatistics(from: self?.retrieveTodayStartDate(from: now) ?? now,
+                                       to: now,
+                                       with: { statistics, _ in
+                completion(statistics)
+            })
+        }
+    }
+
+    func fetchTodayTotalData(type: HKQuantityTypeIdentifier, completion: @escaping (HKStatistics) -> Void) {
+        guard let sampleType = HKSampleType.quantityType(forIdentifier: type)
+        else { return }
+
+        let now = Date()
+        let start = retrieveTodayStartDate(from: now)
+        let predicate = HKQuery.predicateForSamples(withStart: start,
+                                                    end: now,
+                                                    options: .strictStartDate)
+
+        HealthStoreManager.shared.requestStatisticsQuery(type: sampleType, predicate: predicate) { result in
+            completion(result)
+        }
+    }
+
+    private func createTodayPredicate(end: Date = Date()) -> NSPredicate {
+        return HKQuery.predicateForSamples(withStart: retrieveTodayStartDate(from: end),
+                                           end: end,
+                                           options: .strictStartDate)
+    }
+
+    private func retrieveTodayStartDate(from date: Date = Date()) -> Date {
+        return Calendar.current.startOfDay(for: date)
+    }
+}

--- a/Booster/Booster/ViewControllers/Home/HomeViewController.swift
+++ b/Booster/Booster/ViewControllers/Home/HomeViewController.swift
@@ -54,18 +54,22 @@ final class HomeViewController: UIViewController, BaseViewControllerTemplate {
     private func bindHomeViewModel() {
         viewModel.homeModel.bind { [weak self] value in
             DispatchQueue.main.async {
-                self?.todayTotalStepCountLabel.text = "\(value.totalStepCount)"
-                self?.kmLabel.text = String(format: "%.2f", value.km)
-                self?.kcalLabel.text = "\(value.kcal)"
-                self?.timeActiveLabel.text = value.activeTime.stringToMinutesAndSeconds()
-                self?.todayTotalStepCountLabel.layer.opacity = 0
-                self?.configureTotalStepCountLabelGradient(current: Double(value.totalStepCount), goal: 10000)
-                self?.configureHourlyChartView()
-
-                UIView.animate(withDuration: 2) {
-                    self?.todayTotalStepCountLabel.layer.opacity = 1
-                }
+                self?.configureLabels(value)
             }
+        }
+    }
+
+    private func configureLabels(_ value: HomeModel) {
+        todayTotalStepCountLabel.text = "\(value.totalStepCount)"
+        kmLabel.text = String(format: "%.2f", value.km)
+        kcalLabel.text = "\(value.kcal)"
+        timeActiveLabel.text = value.activeTime.stringToMinutesAndSeconds()
+        todayTotalStepCountLabel.layer.opacity = 0
+        configureTotalStepCountLabelGradient(current: Double(value.totalStepCount), goal: 10000)
+        configureHourlyChartView()
+
+        UIView.animate(withDuration: 2) {
+            self.todayTotalStepCountLabel.layer.opacity = 1
         }
     }
 
@@ -84,15 +88,16 @@ final class HomeViewController: UIViewController, BaseViewControllerTemplate {
     private func configureStepRatios(using statisticsCollection: StatisticsCollection) -> [CGFloat] {
         guard let maxStep = statisticsCollection.maxStatistics()?.step
         else { return [CGFloat](repeating: 0, count: 25) }
+        
+        if maxStep == 0 { return [CGFloat](repeating: 0, count: 25) }
 
         var stepRatios = [CGFloat]()
-
         for statistics in statisticsCollection.statistics() {
             let step: Int = statistics.step
             let stepRatio = CGFloat(step) / CGFloat(maxStep)
             stepRatios.append(stepRatio)
         }
-
+        
         if stepRatios.count < 25 {
             stepRatios += [CGFloat](repeating: 0, count: 25 - stepRatios.count)
         }

--- a/Booster/Booster/ViewModels/Home/HomeViewModel.swift
+++ b/Booster/Booster/ViewModels/Home/HomeViewModel.swift
@@ -8,120 +8,82 @@ import Foundation
 import HealthKit
 
 final class HomeViewModel {
-    var homeData: Observable<HomeData> = Observable(HomeData())
+    // MARK: - Properties
+    var homeModel: Observable<HomeModel> = Observable(HomeModel())
 
-    init() { }
+    private let homeUsecase: HomeUsecase
 
+    // MARK: - Init
+    init() { self.homeUsecase = HomeUsecase() }
+
+    // MARK: - Functions
     func fetchQueries() {
-        self.fetchTotalStepCountsData()
-        self.fetchHourlyStepCountsData()
-        self.fetchDistanceData()
-        self.fetchKcalData()
+        self.fetchTodayHourlyStepCountsData()
+        self.fetchTodayDistanceData()
+        self.fetchTodayKcalData()
+        self.fetchTodayTotalStepCountsData()
     }
 
-    private func fetchHourlyStepCountsData() {
-        homeData.value.hourlyStepCount = []
-        guard let stepCountSampleType = HKSampleType.quantityType(forIdentifier: .stepCount),
-              let anchorDate = Calendar.current.date(bySettingHour: 12,
-                                                     minute: 0,
-                                                     second: 0,
-                                                     of: Date())
-        else { return }
-
-        let now = Date()
-        let predicate = createTodayPredicate()
-
-        HealthStoreManager.shared.requestStatisticsCollectionQuery(type: stepCountSampleType,
-                                                                   predicate: predicate,
-                                                                   interval: DateComponents(hour: 1),
-                                                                   anchorDate: anchorDate) { [weak self] result in
-            result.enumerateStatistics(from: self?.retrieveTodayStartDate(from: now) ?? now,
-                                       to: now,
-                                       with: { [weak self] result, _ in
-                    let totalStepForHour = result.sumQuantity()?.doubleValue(for: HKUnit.count()) ?? 0
-                    self?.homeData.value.hourlyStepCount.append(Int(totalStepForHour))
-                }
-            )
+    private func fetchTodayHourlyStepCountsData() {
+        homeUsecase.fetchHourlyStepCountsData { [weak self] statistics in
+            if let quantity = statistics.sumQuantity() {
+                let step = Int(quantity.doubleValue(for: HKUnit.count()))
+                let date = statistics.startDate
+                self?.addEmptyStatisticsIfNeeded(nowDate: date)
+                let entity = Statistics(date: date, step: step)
+                self?.homeModel.value.hourlyStatistics.append(statistics: entity)
+            }
         }
     }
 
-    private func fetchDistanceData() {
-        guard let distanceSampleType = HKSampleType.quantityType(forIdentifier: .distanceWalkingRunning),
-              let anchorDate = Calendar.current.date(bySettingHour: 12,
-                                                minute: 0,
-                                                second: 0,
-                                                of: Date())
-        else { return }
-
-        let now = Date()
-        let predicate = createTodayPredicate()
-
-        HealthStoreManager.shared.requestStatisticsCollectionQuery(type: distanceSampleType,
-                                                                   predicate: predicate,
-                                                                   interval: DateComponents(hour: 1),
-                                                                   anchorDate: anchorDate) { [weak self] result in
-            result.enumerateStatistics(from: self?.retrieveTodayStartDate(from: now) ?? now,
-                                       to: now,
-                                       with: { [weak self] result, _ in
-                    let distance = result.sumQuantity()?.doubleValue(for: HKUnit.meter()) ?? 0
-                    let meter = round(distance * 100) / 100
-                    let km = meter / 1000
-                    self?.homeData.value.km += km
-                }
-            )
+    private func fetchTodayDistanceData() {
+        homeUsecase.fetchTodayTotalData(type: .distanceWalkingRunning) { [weak self] result in
+            let distance = result.sumQuantity()?.doubleValue(for: HKUnit.meter()) ?? 0
+            let km = distance / 1000
+            self?.homeModel.value.km = km
         }
     }
 
-    private func fetchKcalData() {
-        guard let kcalSampleType = HKSampleType.quantityType(forIdentifier: .activeEnergyBurned),
-              let anchorDate = Calendar.current.date(bySettingHour: 12,
-                                                minute: 0,
-                                                second: 0,
-                                                of: Date())
-        else { return }
-
-        let now = Date()
-        let predicate = createTodayPredicate()
-
-        HealthStoreManager.shared.requestStatisticsCollectionQuery(type: kcalSampleType,
-                                                                   predicate: predicate,
-                                                                   interval: DateComponents(hour: 1),
-                                                                   anchorDate: anchorDate) { [weak self] result in
-            result.enumerateStatistics(from: self?.retrieveTodayStartDate(from: now) ?? now,
-                                       to: now,
-                                       with: { [weak self] result, _ in
-                    let kcal = result.sumQuantity()?.doubleValue(for: HKUnit.kilocalorie()) ?? 0
-                    self?.homeData.value.kcal += Int(kcal)
-                }
-            )
+    private func fetchTodayKcalData() {
+        homeUsecase.fetchTodayTotalData(type: .activeEnergyBurned) { [weak self] result in
+            let kcal = result.sumQuantity()?.doubleValue(for: HKUnit.kilocalorie()) ?? 0
+            self?.homeModel.value.kcal = Int(kcal)
         }
     }
 
-    private func fetchTotalStepCountsData() {
-        guard let totalStepSampleType = HKSampleType.quantityType(forIdentifier: .stepCount)
-        else { return }
-
-        let now = Date()
-        let start = retrieveTodayStartDate(from: now)
-        let predicate = HKQuery.predicateForSamples(withStart: start,
-                                                    end: now,
-                                                    options: .strictStartDate)
-
-        HealthStoreManager.shared.requestStatisticsQuery(type: totalStepSampleType, predicate: predicate) { [weak self] result in
+    private func fetchTodayTotalStepCountsData() {
+        homeUsecase.fetchTodayTotalData(type: .stepCount) { [weak self] result in
             guard let seconds = result.duration()?.doubleValue(for: .second()),
-                  let sum = result.sumQuantity()?.doubleValue(for: .count()) else { return }
-            self?.homeData.value.activeTime = TimeInterval(seconds)
-            self?.homeData.value.totalStepCount = Int(sum)
+                  let sum = result.sumQuantity()?.doubleValue(for: .count())
+            else { return }
+
+            self?.homeModel.value.activeTime = TimeInterval(seconds)
+            self?.homeModel.value.totalStepCount = Int(sum)
         }
     }
 
-    private func createTodayPredicate(end: Date = Date()) -> NSPredicate {
-        return HKQuery.predicateForSamples(withStart: retrieveTodayStartDate(from: end),
-                                           end: end,
-                                           options: .strictStartDate)
-    }
+    private func addEmptyStatisticsIfNeeded(nowDate: Date) {
+        let dateformatter = DateFormatter()
+        dateformatter.dateFormat = "hh"
 
-    private func retrieveTodayStartDate(from date: Date = Date()) -> Date {
-        return Calendar.current.startOfDay(for: date)
+        guard let lastStatisticsDate = homeModel.value.hourlyStatistics.statistics().last
+        else {
+            let nowHour = Int(dateformatter.string(from: nowDate)) ?? 0
+            for _ in 0..<nowHour {
+                homeModel.value.hourlyStatistics.append(statistics: Statistics(date: Date(), step: 0))
+            }
+            return
+        }
+
+        let preHour = Int(dateformatter.string(from: lastStatisticsDate.date)) ?? 0
+        let nowHour = Int(dateformatter.string(from: nowDate)) ?? 0
+
+        var interval = nowHour - preHour
+        if interval < 0 { interval += 12 }
+        if interval > 1 {
+            for _ in 0..<interval - 1 {
+                homeModel.value.hourlyStatistics.append(statistics: Statistics(date: Date(), step: 0))
+            }
+        }
     }
 }


### PR DESCRIPTION
### 작업 내용
- 홈페이지 시간별 걸음수 그래프 및 usecase로 viewModel에서 분리

### 체크리스트
- [x] viewModel과 usecase 분리
- [x] 홈페이지 chartView 그래프 설정 

### 구현 설명
- healthKitManager 싱글톤에서 오늘의 데이터만 총합으로 가져오는 방식으로 구현했습니다.
- 중복되는 코드를 줄이고자 today distance, stepcount..등을 fetchTodayData 메소드 하나로 합쳤고, 옵션을 두어 설정가능하도록 변경했습니다.

### 하고싶은 말
- 그래프를 그릴 때, 빈 곳은 따로 비어졌다는 표시를 해줘야하는데, 혹시 그래프 코드에 따로 있을까요? 지금은 따로 뷰모델에서 빈 값은 넣어주도록 하고 있습니다.
