### PR TITLE
[D] 활동 상세 화면 맵킷 연동 & 마일스톤 띄우기 & 글수정페이지 초기설정

### DIFF
--- a/Booster/Booster.xcodeproj/project.pbxproj
+++ b/Booster/Booster.xcodeproj/project.pbxproj
@@ -30,12 +30,12 @@
 		3B31B613274107CF009D9190 /* Tracking+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B31B5FD273CD2F7009D9190 /* Tracking+CoreDataClass.swift */; };
 		3B31B614274107D3009D9190 /* Tracking+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B31B5FE273CD2F7009D9190 /* Tracking+CoreDataProperties.swift */; };
 		3B31B61527410819009D9190 /* UserInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA614F2F2733CDAA00B090D9 /* UserInfo.swift */; };
-		3B31B616274108F3009D9190 /* Observable.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA614F3C2733CDAA00B090D9 /* Observable.swift */; };
+		3B31B616274108F3009D9190 /* BoosterObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA614F3C2733CDAA00B090D9 /* BoosterObservable.swift */; };
 		3B31B61827410935009D9190 /* TrackingProgressUsecase.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA614F502733CDAA00B090D9 /* TrackingProgressUsecase.swift */; };
 		3B31B61B2741097E009D9190 /* HealthStoreManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA614F532733CDAA00B090D9 /* HealthStoreManager.swift */; };
 		3B31B61C2741098C009D9190 /* RepositoryManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA614F262733CDAA00B090D9 /* RepositoryManager.swift */; };
 		3B31B61D27410997009D9190 /* StatisticsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA614F162733CDAA00B090D9 /* StatisticsViewModel.swift */; };
-		3B31B61E274109A5009D9190 /* Observable.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA614F3C2733CDAA00B090D9 /* Observable.swift */; };
+		3B31B61E274109A5009D9190 /* BoosterObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA614F3C2733CDAA00B090D9 /* BoosterObservable.swift */; };
 		3B31B61F274109AF009D9190 /* HealthStoreManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA614F532733CDAA00B090D9 /* HealthStoreManager.swift */; };
 		3B31B62127413664009D9190 /* FeedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B31B62027413664009D9190 /* FeedList.swift */; };
 		3B38FB14273A5F3B00F8620D /* TrackingCountDownView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B38FB13273A5F3B00F8620D /* TrackingCountDownView.swift */; };
@@ -79,7 +79,7 @@
 		FA614F782733CDAA00B090D9 /* UIFont+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA614F392733CDAA00B090D9 /* UIFont+Extension.swift */; };
 		FA614F792733CDAA00B090D9 /* UIAlertController+Extention.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA614F3A2733CDAA00B090D9 /* UIAlertController+Extention.swift */; };
 		FA614F7A2733CDAA00B090D9 /* TimeInterval+extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA614F3B2733CDAA00B090D9 /* TimeInterval+extension.swift */; };
-		FA614F7B2733CDAA00B090D9 /* Observable.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA614F3C2733CDAA00B090D9 /* Observable.swift */; };
+		FA614F7B2733CDAA00B090D9 /* BoosterObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA614F3C2733CDAA00B090D9 /* BoosterObservable.swift */; };
 		FA614F7C2733CDAA00B090D9 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA614F3E2733CDAA00B090D9 /* AppDelegate.swift */; };
 		FA614F7D2733CDAA00B090D9 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA614F3F2733CDAA00B090D9 /* SceneDelegate.swift */; };
 		FA614F7E2733CDAA00B090D9 /* StatisticsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA614F412733CDAA00B090D9 /* StatisticsViewController.swift */; };
@@ -181,7 +181,7 @@
 		FA614F392733CDAA00B090D9 /* UIFont+Extension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIFont+Extension.swift"; sourceTree = "<group>"; };
 		FA614F3A2733CDAA00B090D9 /* UIAlertController+Extention.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIAlertController+Extention.swift"; sourceTree = "<group>"; };
 		FA614F3B2733CDAA00B090D9 /* TimeInterval+extension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "TimeInterval+extension.swift"; sourceTree = "<group>"; };
-		FA614F3C2733CDAA00B090D9 /* Observable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Observable.swift; sourceTree = "<group>"; };
+		FA614F3C2733CDAA00B090D9 /* BoosterObservable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BoosterObservable.swift; sourceTree = "<group>"; };
 		FA614F3E2733CDAA00B090D9 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		FA614F3F2733CDAA00B090D9 /* SceneDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		FA614F412733CDAA00B090D9 /* StatisticsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StatisticsViewController.swift; sourceTree = "<group>"; };
@@ -557,7 +557,7 @@
 				FA614F392733CDAA00B090D9 /* UIFont+Extension.swift */,
 				FA614F3A2733CDAA00B090D9 /* UIAlertController+Extention.swift */,
 				FA614F3B2733CDAA00B090D9 /* TimeInterval+extension.swift */,
-				FA614F3C2733CDAA00B090D9 /* Observable.swift */,
+				FA614F3C2733CDAA00B090D9 /* BoosterObservable.swift */,
 				FA614F8F2733D2CA00B090D9 /* UIColor+Extension.swift */,
 				FA473A04273A1F8A0000C5DC /* UIImage+Extension.swift */,
 				28C96FF2273A4634005BD7BC /* UIResponder+Extension.swift */,
@@ -842,7 +842,7 @@
 			files = (
 				37852ACF273C27F100BA3D67 /* StatisticsModelTests.swift in Sources */,
 				3B31B61F274109AF009D9190 /* HealthStoreManager.swift in Sources */,
-				3B31B61E274109A5009D9190 /* Observable.swift in Sources */,
+				3B31B61E274109A5009D9190 /* BoosterObservable.swift in Sources */,
 				37852AD8273C2D0B00BA3D67 /* StatisticsViewModelTests.swift in Sources */,
 				37852AD6273C286D00BA3D67 /* Statistics.swift in Sources */,
 				3B31B61D27410997009D9190 /* StatisticsViewModel.swift in Sources */,
@@ -862,7 +862,7 @@
 				3B31B61C2741098C009D9190 /* RepositoryManager.swift in Sources */,
 				3B31B612274107BD009D9190 /* TrackingModel.swift in Sources */,
 				3B31B61B2741097E009D9190 /* HealthStoreManager.swift in Sources */,
-				3B31B616274108F3009D9190 /* Observable.swift in Sources */,
+				3B31B616274108F3009D9190 /* BoosterObservable.swift in Sources */,
 				3B31B614274107D3009D9190 /* Tracking+CoreDataProperties.swift in Sources */,
 				3B31B61527410819009D9190 /* UserInfo.swift in Sources */,
 				3B31B611274107BA009D9190 /* Coordinate.swift in Sources */,
@@ -901,7 +901,7 @@
 				FA614F7E2733CDAA00B090D9 /* StatisticsViewController.swift in Sources */,
 				FA614F862733CDAA00B090D9 /* PhotoAnnotationView.swift in Sources */,
 				FA614F942733D51C00B090D9 /* EnrollViewController.swift in Sources */,
-				FA614F7B2733CDAA00B090D9 /* Observable.swift in Sources */,
+				FA614F7B2733CDAA00B090D9 /* BoosterObservable.swift in Sources */,
 				FA614F7F2733CDAA00B090D9 /* HomeViewController.swift in Sources */,
 				28C9702D273C3041005BD7BC /* DetailFeedUsecase.swift in Sources */,
 				FA614F8A2733CDAA00B090D9 /* TrackingProgressUsecase.swift in Sources */,

--- a/Booster/Booster.xcodeproj/project.pbxproj
+++ b/Booster/Booster.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		28C96FF3273A4634005BD7BC /* UIResponder+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28C96FF2273A4634005BD7BC /* UIResponder+Extension.swift */; };
 		28C9702D273C3041005BD7BC /* DetailFeedUsecase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28C9702C273C3041005BD7BC /* DetailFeedUsecase.swift */; };
 		28C9702F2740D731005BD7BC /* HomeUsecase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28C9702E2740D731005BD7BC /* HomeUsecase.swift */; };
+		28C970312744EB64005BD7BC /* ModifyFeedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28C970302744EB64005BD7BC /* ModifyFeedViewController.swift */; };
 		37852ACF273C27F100BA3D67 /* StatisticsModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37852ACE273C27F100BA3D67 /* StatisticsModelTests.swift */; };
 		37852AD6273C286D00BA3D67 /* Statistics.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA614F302733CDAA00B090D9 /* Statistics.swift */; };
 		37852AD8273C2D0B00BA3D67 /* StatisticsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37852AD7273C2D0B00BA3D67 /* StatisticsViewModelTests.swift */; };
@@ -125,6 +126,7 @@
 		28C96FF2273A4634005BD7BC /* UIResponder+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIResponder+Extension.swift"; sourceTree = "<group>"; };
 		28C9702C273C3041005BD7BC /* DetailFeedUsecase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailFeedUsecase.swift; sourceTree = "<group>"; };
 		28C9702E2740D731005BD7BC /* HomeUsecase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeUsecase.swift; sourceTree = "<group>"; };
+		28C970302744EB64005BD7BC /* ModifyFeedViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModifyFeedViewController.swift; sourceTree = "<group>"; };
 		37852ACC273C27F100BA3D67 /* StatisticsTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = StatisticsTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		37852ACE273C27F100BA3D67 /* StatisticsModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatisticsModelTests.swift; sourceTree = "<group>"; };
 		37852AD7273C2D0B00BA3D67 /* StatisticsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatisticsViewModelTests.swift; sourceTree = "<group>"; };
@@ -326,6 +328,7 @@
 			children = (
 				FA614F472733CDAA00B090D9 /* FeedViewController.swift */,
 				28C96FEA27396892005BD7BC /* DetailFeedViewController.swift */,
+				28C970302744EB64005BD7BC /* ModifyFeedViewController.swift */,
 			);
 			path = Feed;
 			sourceTree = "<group>";
@@ -917,6 +920,7 @@
 				3B31B600273CD2F7009D9190 /* Tracking+CoreDataProperties.swift in Sources */,
 				FA614F5C2733CDAA00B090D9 /* StatisticsViewModel.swift in Sources */,
 				FA614F8B2733CDAA00B090D9 /* HealthStoreManager.swift in Sources */,
+				28C970312744EB64005BD7BC /* ModifyFeedViewController.swift in Sources */,
 				FA614F8E2733CF9000B090D9 /* EmptyView.swift in Sources */,
 				FA614F772733CDAA00B090D9 /* NSAttributedString+Extension.swift in Sources */,
 				FA614F6C2733CDAA00B090D9 /* Booster.xcdatamodeld in Sources */,

--- a/Booster/Booster/Extensions/BoosterObservable.swift
+++ b/Booster/Booster/Extensions/BoosterObservable.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-final class Observable<T> {
+final class BoosterObservable<T> {
     private var listener: ((T) -> Void)?
 
     var value: T {

--- a/Booster/Booster/Models/MileStone.swift
+++ b/Booster/Booster/Models/MileStone.swift
@@ -17,9 +17,9 @@ final class MileStone: NSObject, NSCoding {
     public init?(coder: NSCoder) {
         coordinate = Coordinate(latitude: 0, longitude: 0)
         imageData = Data()
-        if let coord = coder.decodeObject(forKey: "coordinate") as? Coordinate,
-              let data = coder.decodeObject(forKey: "imageData") as? Data {
-            coordinate = coord
+        if let coordinate = coder.decodeObject(forKey: "coordinate") as? Coordinate,
+           let data = coder.decodeObject(forKey: "imageData") as? Data {
+            self.coordinate = coordinate
             imageData = data
         }
     }

--- a/Booster/Booster/Storyboards/Feed.storyboard
+++ b/Booster/Booster/Storyboards/Feed.storyboard
@@ -284,7 +284,7 @@
                         <barButtonItem key="rightBarButtonItem" title="Item" image="gearshape.fill" catalog="system" id="GPP-8c-MDj">
                             <color key="tintColor" name="boosterLabel"/>
                             <connections>
-                                <action selector="settingButtonDidTapped:" destination="SNN-pe-2iF" id="KDF-Ax-xLJ"/>
+                                <action selector="settingButtonDidTap:" destination="SNN-pe-2iF" id="gk5-FN-h0Z"/>
                             </connections>
                         </barButtonItem>
                     </navigationItem>

--- a/Booster/Booster/Storyboards/Feed.storyboard
+++ b/Booster/Booster/Storyboards/Feed.storyboard
@@ -50,7 +50,7 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="6ko-pE-sq5">
-                                                    <rect key="frame" x="20" y="20" width="135" height="150"/>
+                                                    <rect key="frame" x="40" y="20" width="135" height="150"/>
                                                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="135" id="Iaf-vO-2ie"/>
@@ -92,7 +92,7 @@
                                                 <constraint firstAttribute="bottom" secondItem="6ko-pE-sq5" secondAttribute="bottom" constant="20" id="fG9-hb-RKG"/>
                                                 <constraint firstItem="9Lz-29-Ne5" firstAttribute="leading" secondItem="Wj7-91-8AJ" secondAttribute="leading" constant="20" id="gtf-o6-hh8"/>
                                                 <constraint firstItem="9Lz-29-Ne5" firstAttribute="centerY" secondItem="6VG-7y-nXI" secondAttribute="centerY" id="uzN-3f-dfr"/>
-                                                <constraint firstItem="6ko-pE-sq5" firstAttribute="leading" secondItem="Wj7-91-8AJ" secondAttribute="leading" constant="20" id="xCk-Xn-oea"/>
+                                                <constraint firstItem="6ko-pE-sq5" firstAttribute="leading" secondItem="Wj7-91-8AJ" secondAttribute="leading" constant="40" id="xCk-Xn-oea"/>
                                                 <constraint firstItem="8Hf-V6-ZrQ" firstAttribute="top" secondItem="9Lz-29-Ne5" secondAttribute="bottom" constant="10" id="yDr-jO-0LX"/>
                                             </constraints>
                                         </collectionViewCellContentView>
@@ -157,7 +157,7 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="gangnam-gu" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fmg-7e-yqO">
-                                                <rect key="frame" x="30" y="78.5" width="69" height="17.5"/>
+                                                <rect key="frame" x="30" y="73.5" width="69" height="17.5"/>
                                                 <fontDescription key="fontDescription" name="NotoSansKR-Light" family="Noto Sans KR" pointSize="12"/>
                                                 <color key="textColor" name="boosterLabel"/>
                                                 <nil key="highlightedColor"/>
@@ -187,13 +187,13 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="kcal" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="uRb-Us-F76">
-                                                <rect key="frame" x="56.5" y="625.5" width="28" height="22"/>
+                                                <rect key="frame" x="56.5" y="620.5" width="28" height="22"/>
                                                 <fontDescription key="fontDescription" name="NotoSansKR-Light" family="Noto Sans KR" pointSize="15"/>
                                                 <color key="textColor" name="boosterLabel"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="time" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TeL-Ss-n73">
-                                                <rect key="frame" x="191.5" y="625.5" width="31" height="22"/>
+                                                <rect key="frame" x="191.5" y="620.5" width="31" height="22"/>
                                                 <fontDescription key="fontDescription" name="NotoSansKR-Light" family="Noto Sans KR" pointSize="15"/>
                                                 <color key="textColor" name="boosterLabel"/>
                                                 <nil key="highlightedColor"/>
@@ -211,7 +211,7 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" userInteractionEnabled="NO" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="BvC-uD-hJr">
-                                                <rect key="frame" x="30" y="677.5" width="354" height="466"/>
+                                                <rect key="frame" x="30" y="672.5" width="354" height="466"/>
                                                 <color key="backgroundColor" name="boosterBackground"/>
                                                 <color key="tintColor" name="boosterOrange"/>
                                                 <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>
@@ -220,7 +220,7 @@
                                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                                             </textView>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="km" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ekR-0F-WEU">
-                                                <rect key="frame" x="329.5" y="625.5" width="21" height="22"/>
+                                                <rect key="frame" x="329.5" y="620.5" width="21" height="22"/>
                                                 <fontDescription key="fontDescription" name="NotoSansKR-Light" family="Noto Sans KR" pointSize="15"/>
                                                 <color key="textColor" name="boosterLabel"/>
                                                 <nil key="highlightedColor"/>
@@ -232,9 +232,9 @@
                                             <constraint firstItem="BvC-uD-hJr" firstAttribute="leading" secondItem="ecH-rG-cv5" secondAttribute="leading" constant="30" id="6n0-Yh-AgM"/>
                                             <constraint firstItem="ph3-zt-nOG" firstAttribute="leading" secondItem="B7Q-Cx-YM2" secondAttribute="trailing" constant="5" id="6pf-H5-nsu"/>
                                             <constraint firstItem="gCe-Qv-haU" firstAttribute="leading" secondItem="ecH-rG-cv5" secondAttribute="leading" constant="30" id="8ze-tr-Ag4"/>
-                                            <constraint firstItem="uRb-Us-F76" firstAttribute="top" secondItem="EpB-cC-q10" secondAttribute="bottom" constant="10" id="A8K-Kg-WAC"/>
+                                            <constraint firstItem="uRb-Us-F76" firstAttribute="top" secondItem="EpB-cC-q10" secondAttribute="bottom" constant="5" id="A8K-Kg-WAC"/>
                                             <constraint firstItem="BvC-uD-hJr" firstAttribute="height" secondItem="ecH-rG-cv5" secondAttribute="height" multiplier="0.4" id="Bbl-PW-DT2"/>
-                                            <constraint firstItem="ekR-0F-WEU" firstAttribute="top" secondItem="NJw-v9-DGj" secondAttribute="bottom" constant="10" id="EgE-ia-94I"/>
+                                            <constraint firstItem="ekR-0F-WEU" firstAttribute="top" secondItem="NJw-v9-DGj" secondAttribute="bottom" constant="5" id="EgE-ia-94I"/>
                                             <constraint firstItem="ekR-0F-WEU" firstAttribute="centerX" secondItem="NJw-v9-DGj" secondAttribute="centerX" multiplier="0.996" id="Ern-VA-dkd"/>
                                             <constraint firstItem="HR9-G6-PmX" firstAttribute="centerY" secondItem="EpB-cC-q10" secondAttribute="centerY" id="GDb-Pj-kOs"/>
                                             <constraint firstItem="IQ7-gI-wGX" firstAttribute="top" secondItem="ecH-rG-cv5" secondAttribute="top" constant="30" id="IOk-ee-oOH"/>
@@ -245,13 +245,13 @@
                                             <constraint firstAttribute="trailing" secondItem="BvC-uD-hJr" secondAttribute="trailing" constant="30" id="aBf-Np-4Tm"/>
                                             <constraint firstItem="TeL-Ss-n73" firstAttribute="centerX" secondItem="ecH-rG-cv5" secondAttribute="centerX" id="aJS-hd-K3F"/>
                                             <constraint firstItem="IQ7-gI-wGX" firstAttribute="leading" secondItem="ecH-rG-cv5" secondAttribute="leading" constant="30" id="bmG-LK-fiH"/>
-                                            <constraint firstItem="TeL-Ss-n73" firstAttribute="top" secondItem="HR9-G6-PmX" secondAttribute="bottom" constant="10" id="g3n-CJ-Ne4"/>
-                                            <constraint firstItem="fmg-7e-yqO" firstAttribute="top" secondItem="IQ7-gI-wGX" secondAttribute="bottom" constant="5" id="hwP-KN-Bxs"/>
+                                            <constraint firstItem="TeL-Ss-n73" firstAttribute="top" secondItem="HR9-G6-PmX" secondAttribute="bottom" constant="5" id="g3n-CJ-Ne4"/>
+                                            <constraint firstItem="fmg-7e-yqO" firstAttribute="top" secondItem="IQ7-gI-wGX" secondAttribute="bottom" id="hwP-KN-Bxs"/>
                                             <constraint firstItem="fmg-7e-yqO" firstAttribute="leading" secondItem="IQ7-gI-wGX" secondAttribute="leading" id="mAQ-99-0ua"/>
                                             <constraint firstItem="B7Q-Cx-YM2" firstAttribute="leading" secondItem="gCe-Qv-haU" secondAttribute="leading" id="oMt-2A-YyO"/>
                                             <constraint firstItem="BvC-uD-hJr" firstAttribute="top" secondItem="uRb-Us-F76" secondAttribute="bottom" constant="30" id="pG2-7w-zr2"/>
                                             <constraint firstItem="NJw-v9-DGj" firstAttribute="centerX" secondItem="ecH-rG-cv5" secondAttribute="centerX" multiplier="1.65" id="pw5-Oo-kn8"/>
-                                            <constraint firstItem="gCe-Qv-haU" firstAttribute="top" secondItem="fmg-7e-yqO" secondAttribute="bottom" constant="10" id="uBy-U9-QZy"/>
+                                            <constraint firstItem="gCe-Qv-haU" firstAttribute="top" secondItem="fmg-7e-yqO" secondAttribute="bottom" constant="15" id="uBy-U9-QZy"/>
                                             <constraint firstItem="uRb-Us-F76" firstAttribute="centerX" secondItem="EpB-cC-q10" secondAttribute="centerX" multiplier="0.97" id="uGV-eB-HQo"/>
                                             <constraint firstItem="EpB-cC-q10" firstAttribute="centerX" secondItem="ecH-rG-cv5" secondAttribute="centerX" multiplier="0.35" id="vRq-V5-J4m"/>
                                             <constraint firstItem="HR9-G6-PmX" firstAttribute="centerX" secondItem="ecH-rG-cv5" secondAttribute="centerX" multiplier="1.008" id="vcf-e9-WXa"/>
@@ -280,18 +280,70 @@
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" largeTitleDisplayMode="never" id="cYC-aO-Ox6">
-                        <barButtonItem key="rightBarButtonItem" title="Item" id="GPP-8c-MDj"/>
+                        <barButtonItem key="backBarButtonItem" title="    " id="FPd-K5-IyH"/>
+                        <barButtonItem key="rightBarButtonItem" title="Item" image="gearshape.fill" catalog="system" id="GPP-8c-MDj">
+                            <color key="tintColor" name="boosterLabel"/>
+                            <connections>
+                                <action selector="settingButtonDidTapped:" destination="SNN-pe-2iF" id="KDF-Ax-xLJ"/>
+                            </connections>
+                        </barButtonItem>
                     </navigationItem>
                     <connections>
+                        <outlet property="contentTextView" destination="BvC-uD-hJr" id="hOH-Qn-ZtH"/>
+                        <outlet property="kcalLabel" destination="EpB-cC-q10" id="Xit-5s-Jm9"/>
+                        <outlet property="kmLabel" destination="NJw-v9-DGj" id="piY-uh-M8H"/>
                         <outlet property="locationInfoLabel" destination="fmg-7e-yqO" id="abW-0v-V0D"/>
                         <outlet property="mapView" destination="gCe-Qv-haU" id="hvC-1M-ox1"/>
                         <outlet property="stepCountsLabel" destination="B7Q-Cx-YM2" id="ILD-Ty-DIC"/>
+                        <outlet property="timeLabel" destination="HR9-G6-PmX" id="YSh-Yn-HAk"/>
                         <outlet property="titleLabel" destination="IQ7-gI-wGX" id="PhN-PO-4Os"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="psD-uM-Jpp" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="2132" y="98"/>
+        </scene>
+        <!--Modify Feed View Controller-->
+        <scene sceneID="4pK-ub-82t">
+            <objects>
+                <viewController storyboardIdentifier="ModifyFeedViewController" hidesBottomBarWhenPushed="YES" id="f3O-Yw-uaq" customClass="ModifyFeedViewController" customModule="Booster" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="2Vp-SG-z2Q">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" text="아직 안했지롱" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="0sF-uL-ly2">
+                                <rect key="frame" x="30" y="136" width="354" height="696"/>
+                                <color key="backgroundColor" name="boosterBackground"/>
+                                <color key="textColor" name="boosterLabel"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="18"/>
+                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                            </textView>
+                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="라랄라" placeholder="제목" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="eKE-zl-J4v">
+                                <rect key="frame" x="30" y="74" width="354" height="45"/>
+                                <color key="textColor" name="boosterLabel"/>
+                                <fontDescription key="fontDescription" name="NotoSansKR-Medium" family="Noto Sans KR" pointSize="30"/>
+                                <textInputTraits key="textInputTraits"/>
+                            </textField>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="i2n-DW-KoS"/>
+                        <color key="backgroundColor" name="boosterBackground"/>
+                        <constraints>
+                            <constraint firstItem="0sF-uL-ly2" firstAttribute="leading" secondItem="i2n-DW-KoS" secondAttribute="leading" constant="30" id="3kK-lO-OBJ"/>
+                            <constraint firstItem="i2n-DW-KoS" firstAttribute="trailing" secondItem="eKE-zl-J4v" secondAttribute="trailing" constant="30" id="LqB-84-OGk"/>
+                            <constraint firstItem="i2n-DW-KoS" firstAttribute="bottom" secondItem="0sF-uL-ly2" secondAttribute="bottom" constant="30" id="QF9-h0-KgK"/>
+                            <constraint firstItem="eKE-zl-J4v" firstAttribute="leading" secondItem="i2n-DW-KoS" secondAttribute="leading" constant="30" id="Vgn-fO-7On"/>
+                            <constraint firstItem="eKE-zl-J4v" firstAttribute="top" secondItem="i2n-DW-KoS" secondAttribute="top" constant="30" id="ViH-MJ-THV"/>
+                            <constraint firstItem="0sF-uL-ly2" firstAttribute="top" secondItem="eKE-zl-J4v" secondAttribute="bottom" constant="17" id="rpQ-wj-u4f"/>
+                            <constraint firstItem="i2n-DW-KoS" firstAttribute="trailing" secondItem="0sF-uL-ly2" secondAttribute="trailing" constant="30" id="y6e-qk-VRg"/>
+                        </constraints>
+                    </view>
+                    <toolbarItems/>
+                    <nil key="simulatedTopBarMetrics"/>
+                    <nil key="simulatedBottomBarMetrics"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="JpP-0M-g5F" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="3022" y="98"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="j4Y-rs-hEH">
@@ -301,9 +353,9 @@
                     <navigationBar key="navigationBar" contentMode="scaleToFill" backIndicatorImage="arrow.backward" catalog="system" largeTitles="YES" backIndicatorTransitionMaskImage="arrow.backward" id="VuG-05-Ips">
                         <rect key="frame" x="0.0" y="44" width="414" height="96"/>
                         <autoresizingMask key="autoresizingMask"/>
-                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                        <color key="tintColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                        <color key="barTintColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <color key="backgroundColor" name="boosterBackground"/>
+                        <color key="tintColor" name="boosterLabel"/>
+                        <color key="barTintColor" name="boosterBackground"/>
                         <textAttributes key="titleTextAttributes">
                             <color key="textColor" name="boosterLabel"/>
                         </textAttributes>
@@ -324,6 +376,7 @@
     </scenes>
     <resources>
         <image name="arrow.backward" catalog="system" width="128" height="98"/>
+        <image name="gearshape.fill" catalog="system" width="128" height="121"/>
         <image name="newspaper" catalog="system" width="128" height="111"/>
         <image name="newspaper.fill" catalog="system" width="128" height="111"/>
         <namedColor name="boosterBackground">

--- a/Booster/Booster/Usecases/DetailFeedUsecase.swift
+++ b/Booster/Booster/Usecases/DetailFeedUsecase.swift
@@ -9,8 +9,13 @@ import Foundation
 import CoreData
 
 final class DetailFeedUsecase {
-    private let entityName: String = "Tracking"
-    private let repository: RepositoryManager = RepositoryManager()
+    private let entityName: String
+    private let repository: RepositoryManager
+
+    init() {
+        entityName = "Tracking"
+        repository = RepositoryManager()
+    }
 
     func fetch(predicate: NSPredicate, completion handler: @escaping ([TrackingModel]) -> Void) {
         repository.fetch(entityName: entityName, predicate: predicate) { (response: Result<[Tracking], Error>) in

--- a/Booster/Booster/Usecases/HomeUsecase.swift
+++ b/Booster/Booster/Usecases/HomeUsecase.swift
@@ -6,43 +6,50 @@
 //
 import Foundation
 import HealthKit
+import RxSwift
 
 final class HomeUsecase {
-    func fetchHourlyStepCountsData(completion: @escaping (HKStatistics) -> Void) {
-        guard let stepCountSampleType = HKSampleType.quantityType(forIdentifier: .stepCount),
-              let anchorDate = Calendar.current.date(bySettingHour: 0,
-                                                     minute: 0,
-                                                     second: 0,
-                                                     of: Date())
-        else { return }
+    func fetchHourlyStepCountsData() -> Observable<HKStatistics> {
+        return Observable.create { [weak self] observer in
+            guard let stepCountSampleType = HKSampleType.quantityType(forIdentifier: .stepCount),
+                  let anchorDate = Calendar.current.date(bySettingHour: 0,
+                                                         minute: 0,
+                                                         second: 0,
+                                                         of: Date()),
+                  let predicate = self?.createTodayPredicate()
+            else { return Disposables.create() }
 
-        let now = Date()
-        let predicate = createTodayPredicate()
+            let now = Date()
 
-        HealthStoreManager.shared.requestStatisticsCollectionQuery(type: stepCountSampleType,
-                                                                   predicate: predicate,
-                                                                   interval: DateComponents(hour: 1),
-                                                                   anchorDate: anchorDate) { result in
-            result.enumerateStatistics(from: Calendar.current.startOfDay(for: now),
-                                       to: now,
-                                       with: { statistics, _ in
-                completion(statistics)
-            })
+            HealthStoreManager.shared.requestStatisticsCollectionQuery(type: stepCountSampleType,
+                                                                       predicate: predicate,
+                                                                       interval: DateComponents(hour: 1),
+                                                                       anchorDate: anchorDate) { result in
+                result.enumerateStatistics(from: Calendar.current.startOfDay(for: now),
+                                           to: now,
+                                           with: { statistics, _ in
+                    observer.onNext(statistics)
+                })
+            }
+            return Disposables.create()
         }
     }
 
-    func fetchTodayTotalData(type: HKQuantityTypeIdentifier, completion: @escaping (HKStatistics) -> Void) {
-        guard let sampleType = HKSampleType.quantityType(forIdentifier: type)
-        else { return }
+    func fetchTodayTotalData(type: HKQuantityTypeIdentifier) -> Observable<HKStatistics> {
+        return Observable.create { observer in
+            guard let sampleType = HKSampleType.quantityType(forIdentifier: type)
+            else { return Disposables.create() }
 
-        let now = Date()
-        let start = Calendar.current.startOfDay(for: now)
-        let predicate = HKQuery.predicateForSamples(withStart: start,
-                                                    end: now,
-                                                    options: .strictStartDate)
+            let now = Date()
+            let start = Calendar.current.startOfDay(for: now)
+            let predicate = HKQuery.predicateForSamples(withStart: start,
+                                                        end: now,
+                                                        options: .strictStartDate)
 
-        HealthStoreManager.shared.requestStatisticsQuery(type: sampleType, predicate: predicate) { result in
-            completion(result)
+            HealthStoreManager.shared.requestStatisticsQuery(type: sampleType, predicate: predicate) { result in
+                observer.onNext(result)
+            }
+            return Disposables.create()
         }
     }
 

--- a/Booster/Booster/Usecases/TrackingProgressUsecase.swift
+++ b/Booster/Booster/Usecases/TrackingProgressUsecase.swift
@@ -27,13 +27,13 @@ final class TrackingProgressUsecase {
         static let imageData: String = "imageData"
     }
 
-    private var errors: Observable<[TrackingError?]>
+    private var errors: BoosterObservable<[TrackingError?]>
     private var handler: ((TrackingError?) -> Void)?
     private let entity: String
     private let repository: RepositoryManager
 
     init() {
-        errors = Observable([])
+        errors = BoosterObservable([])
         entity = "Tracking"
         repository = RepositoryManager()
         errors.bind { values in

--- a/Booster/Booster/ViewControllers/Feed/DetailFeedViewController.swift
+++ b/Booster/Booster/ViewControllers/Feed/DetailFeedViewController.swift
@@ -45,7 +45,7 @@ final class DetailFeedViewController: UIViewController, BaseViewControllerTempla
     }
 
     // MARK: - @IBActions
-    @IBAction private func settingButtonDidTapped(_ sender: UIBarButtonItem) {
+    @IBAction private func settingButtonDidTap(_ sender: UIBarButtonItem) {
         let settingAlertController = UIAlertController(title: nil,
                                                        message: nil,
                                                        preferredStyle: .actionSheet)

--- a/Booster/Booster/ViewControllers/Feed/DetailFeedViewController.swift
+++ b/Booster/Booster/ViewControllers/Feed/DetailFeedViewController.swift
@@ -13,16 +13,28 @@ protocol DetailFeedModelDelegate: AnyObject {
 }
 
 final class DetailFeedViewController: UIViewController, BaseViewControllerTemplate {
-    weak var delegate: DetailFeedModelDelegate?
+    // MARK: - Enum
+    enum NibName {
+        static let photoAnnotationView = "PhotoAnnotationView"
+    }
 
-    // MARK: Properties
+    enum AnnotationIdentifier: String {
+        case milestone
+        case dot
+    }
 
+    // MARK: - Properties
     @IBOutlet private weak var titleLabel: UILabel!
     @IBOutlet private weak var locationInfoLabel: UILabel!
-    @IBOutlet private weak var mapView: MKMapView!
     @IBOutlet private weak var stepCountsLabel: UILabel!
+    @IBOutlet private weak var kcalLabel: UILabel!
+    @IBOutlet private weak var timeLabel: UILabel!
+    @IBOutlet private weak var kmLabel: UILabel!
 
-    // var trackingInfo: TrackingRecord?
+    @IBOutlet private weak var contentTextView: UITextView!
+    @IBOutlet private weak var mapView: MKMapView!
+
+    weak var delegate: DetailFeedModelDelegate?
     var viewModel = DetailFeedViewModel()
 
     // MARK: - Life Cycles
@@ -32,42 +44,125 @@ final class DetailFeedViewController: UIViewController, BaseViewControllerTempla
         configure()
     }
 
+    // MARK: - @IBActions
+    @IBAction private func settingButtonDidTapped(_ sender: UIBarButtonItem) {
+        let settingAlertController = UIAlertController(title: nil,
+                                                       message: nil,
+                                                       preferredStyle: .actionSheet)
+        let modifyAction = UIAlertAction(title: "글 수정", style: .default) { _ in
+            guard let modifyViewController = self.storyboard?.instantiateViewController(withIdentifier: ModifyFeedViewController.identifier) as? ModifyFeedViewController
+            else { return }
+            modifyViewController.title = "글 수정"
+            self.navigationController?.pushViewController(modifyViewController, animated: true)
+        }
+        let shareAction = UIAlertAction(title: "공유하기", style: .default) { _ in
+
+        }
+        let deleteAction = UIAlertAction(title: "글 삭제", style: .destructive) { _ in
+
+        }
+        let closeAction = UIAlertAction(title: "닫기", style: .cancel) { _ in
+
+        }
+        settingAlertController.addAction(modifyAction)
+        settingAlertController.addAction(shareAction)
+        settingAlertController.addAction(deleteAction)
+        settingAlertController.addAction(closeAction)
+
+        present(settingAlertController,
+                animated: true,
+                completion: nil)
+    }
+
+    // MARK: - Functions
     func configure() {
         delegate?.detailFeed(viewModel: viewModel)
-        mapView.layer.cornerRadius = mapView.frame.height / 15
+        mapView.layer.cornerRadius = mapView.frame.height / 17
         mapView.delegate = self
 
-//        viewModel.trackingModel.bind { [weak self] value in
-//            guard let self = self
-//            else { return }
-//            value.forEach {
-//                self.titleLabel.text = $0.title
-//                self.locationInfoLabel.text = "\($0.endDate ?? Date())"
-//                self.stepCountsLabel.text = "\($0.steps)"
-//
-//                var points: [CLLocationCoordinate2D] = []
-//                let point1 = CLLocationCoordinate2DMake(37.6659862, 126.7710653)
-//                let point2 = CLLocationCoordinate2DMake(37.6667059, 126.7714045)
-//                let point3 = CLLocationCoordinate2DMake(37.6688112, 126.7705767)
-//                points.append(point1)
-//                points.append(point2)
-//                points.append(point3)
-//
-//                self.createPolyLine(points: points)
-//            }
-//        }
+        viewModel.trackingModel.bind { [weak self] value in
+            DispatchQueue.main.async {
+                self?.configureUI(value: value)
+            }
+        }
     }
 
-    private func createPolyLine(points: [CLLocationCoordinate2D]) {
-        mapView.setRegion(MKCoordinateRegion(center: points[0], latitudinalMeters: 300, longitudinalMeters: 300), animated: false)
+    private func configureUI(value: TrackingModel) {
+        if value.coordinates.count == 0 { return }
+        let points = value.coordinates.filter { $0.latitude != nil && $0.longitude != nil }
+            .map { CLLocationCoordinate2DMake($0.latitude!, $0.longitude!) }
 
-        let lineDraw = MKPolyline(coordinates: points, count: points.count)
-        mapView.addOverlay(lineDraw)
+        titleLabel.text = value.title
+        stepCountsLabel.text = "\(value.steps)"
+        kcalLabel.text = "\(value.calories)"
+        timeLabel.text = TimeInterval(value.seconds).stringToMinutesAndSeconds()
+        kmLabel.text = String(format: "%.2f", value.distance)
+        contentTextView.text = value.content
+        createPolyLine(points: points, meter: value.distance)
+
+        for mileStone in value.milestones {
+            guard let latitude = mileStone.coordinate.latitude,
+                  let longitude = mileStone.coordinate.longitude
+            else { continue }
+
+            addAnnotation(type: .milestone,
+                          latitude,
+                          longitude)
+        }
     }
 
-    // 우리나라기준 위도 약 1도: 110km, 1분 1.8km, 1초 30m
-    // 경도 약 1도: 88.74km, 1분: 1.479km, 1초: 0.024km = 24m
-    private func configureWholeRegion(points: [CLLocationCoordinate2D]) {
+    private func createPolyLine(points: [CLLocationCoordinate2D], meter: Double) {
+        let ((minLatitude, maxLatitude), (minLongitude, maxLongitude)) = points.reduce(((90.0, -90.0), (180.0, -180.0))) { next, current in
+            ((min(current.latitude, next.0.0), max(current.latitude, next.0.1)), (min(current.longitude, next.1.0), max(current.longitude, next.1.1)))
+        }
+        let centerLatitude = (minLatitude + maxLatitude) / 2
+        let centerLongitude = (minLongitude + maxLongitude) / 2
+        let meters = meter + 50
+
+        mapView.setRegion(MKCoordinateRegion(center: CLLocationCoordinate2D(latitude: centerLatitude, longitude: centerLongitude),
+                                             latitudinalMeters: meters,
+                                             longitudinalMeters: meters), animated: false)
+
+        for (index, point) in points.enumerated() {
+            if index > points.count - 2 { break }
+            if index == 0 || index == points.count - 2 {
+                addAnnotation(type: .dot,
+                              point.latitude,
+                              point.longitude)
+            }
+            drawPath(from: point, to: points[index + 1])
+        }
+    }
+
+    private func drawPath(from prevCoordinate: CLLocationCoordinate2D?, to currentCoordinate: CLLocationCoordinate2D?) {
+        guard let currentCoordinate = currentCoordinate,
+              let prevCoordinate = prevCoordinate
+        else { return }
+
+        let points: [CLLocationCoordinate2D] = [prevCoordinate, currentCoordinate]
+        let line = MKPolyline(coordinates: points, count: points.count)
+
+        mapView.addOverlay(line)
+    }
+
+    private func addAnnotation(type: AnnotationIdentifier, _ latitude: CLLocationDegrees, _ longitude: CLLocationDegrees) {
+        let annotation = MKPointAnnotation()
+        annotation.coordinate = CLLocationCoordinate2D(latitude: latitude, longitude: longitude)
+        annotation.title = type.rawValue
+
+        mapView.addAnnotation(annotation)
+    }
+
+    private func removeMileStoneAnnotation(of mileStone: MileStone) -> Bool {
+        guard let annotation = mapView.annotations.first(where: {
+            let coordinate = Coordinate(latitude: $0.coordinate.latitude, longitude: $0.coordinate.longitude)
+            return coordinate == mileStone.coordinate
+        })
+        else { return false }
+
+        mapView.removeAnnotation(annotation)
+
+        return true
     }
 }
 
@@ -77,10 +172,75 @@ extension DetailFeedViewController: MKMapViewDelegate {
         guard let polyLine = overlay as? MKPolyline
         else { return MKOverlayRenderer() }
 
-        let renderer = MKPolylineRenderer(polyline: polyLine)
-        renderer.strokeColor = .orange
-        renderer.lineWidth = 5.0
-        renderer.alpha = 1.0
-        return renderer
+        let polyLineRenderer = MKPolylineRenderer(polyline: polyLine)
+        polyLineRenderer.strokeColor = .boosterOrange
+        polyLineRenderer.lineWidth = 8
+        return polyLineRenderer
+    }
+
+    func mapView(_ mapView: MKMapView, viewFor annotation: MKAnnotation) -> MKAnnotationView? {
+        let coordinate = Coordinate(latitude: annotation.coordinate.latitude, longitude: annotation.coordinate.longitude)
+
+        guard let title = annotation.title,
+              let identifier = AnnotationIdentifier(rawValue: title ?? "")
+        else { return nil }
+
+        switch identifier {
+        case .milestone:
+            if let annotationView = mapView.dequeueReusableAnnotationView(withIdentifier: AnnotationIdentifier.milestone.rawValue) {
+                annotationView.annotation = annotation
+                annotationView.canShowCallout = false
+                return annotationView
+            } else {
+                guard let newAnnotationView = UINib(nibName: NibName.photoAnnotationView, bundle: nil).instantiate(withOwner: self, options: nil).first as? PhotoAnnotationView,
+                      let mileStone = viewModel.mileStone(at: coordinate)
+                else { return nil }
+
+                newAnnotationView.canShowCallout = false
+                newAnnotationView.photoImageView.image = UIImage(data: mileStone.imageData)
+                newAnnotationView.photoImageView.backgroundColor = .white
+                newAnnotationView.centerOffset = CGPoint(x: 0, y: -newAnnotationView.frame.height / 2.0)
+                return newAnnotationView
+            }
+        case .dot:
+            if let annotationView = mapView.dequeueReusableAnnotationView(withIdentifier: AnnotationIdentifier.dot.rawValue) {
+                annotationView.annotation = annotation
+                annotationView.isUserInteractionEnabled = false
+                return annotationView
+            } else {
+                let dotSize = CGSize(width: 18, height: 18)
+                let newAnnotationView = MKAnnotationView.init(frame: CGRect(origin: .zero, size: dotSize))
+                newAnnotationView.backgroundColor = .boosterOrange
+                newAnnotationView.isUserInteractionEnabled = false
+                newAnnotationView.layer.cornerRadius = newAnnotationView.frame.height / 2
+                return newAnnotationView
+            }
+        }
+    }
+
+    func mapView(_ mapView: MKMapView, didSelect view: MKAnnotationView) {
+         mapView.deselectAnnotation(view.annotation, animated: false)
+        let coordinate = Coordinate(latitude: view.annotation?.coordinate.latitude, longitude: view.annotation?.coordinate.longitude)
+        guard let selectedMileStone = viewModel.mileStone(at: coordinate)
+        else { return }
+
+        let mileStonePhotoViewModel = MileStonePhotoViewModel(mileStone: selectedMileStone)
+        let mileStonePhotoViewController = MileStonePhotoViewController(viewModel: mileStonePhotoViewModel)
+        mileStonePhotoViewController.viewModel = mileStonePhotoViewModel
+        mileStonePhotoViewController.delegate = self
+
+        present(mileStonePhotoViewController, animated: true, completion: nil)
+    }
+}
+
+// MARK: - MileStone Delete Completed
+extension DetailFeedViewController: MileStonePhotoViewControllerDelegate {
+    func delete(mileStone: MileStone) {
+        if let _ = viewModel.remove(of: mileStone), removeMileStoneAnnotation(of: mileStone) {
+            let title = "삭제 완료"
+            let message = "마일스톤을 삭제했어요"
+            let alertViewController = UIAlertController.simpleAlert(title: title, message: message)
+            present(alertViewController, animated: true)
+        }
     }
 }

--- a/Booster/Booster/ViewControllers/Feed/FeedViewController.swift
+++ b/Booster/Booster/ViewControllers/Feed/FeedViewController.swift
@@ -1,11 +1,12 @@
 import UIKit
 
 final class FeedViewController: UIViewController, BaseViewControllerTemplate {
+    // MARK: - Enum
     private enum Segue {
         static let feedDetailSegue = "feedDetailSegue"
     }
 
-    // MARK: Properties
+    // MARK: - Properties
     @IBOutlet private weak var collectionView: UICollectionView!
 
     var viewModel: FeedViewModel = FeedViewModel()
@@ -22,7 +23,7 @@ final class FeedViewController: UIViewController, BaseViewControllerTemplate {
         return refreshControl
     }()
 
-    // MARK: Life Cycles
+    // MARK: - Life Cycles
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -30,12 +31,12 @@ final class FeedViewController: UIViewController, BaseViewControllerTemplate {
         viewModel.fetch()
     }
 
-    // MARK: @objc Methods
+    // MARK: - @objc
     @objc func refreshPull() {
         viewModel.reset()
     }
 
-    // MARK: Functions
+    // MARK: - Functions
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         guard let detailFeedViewController = segue.destination as? DetailFeedViewController
         else { return }
@@ -115,6 +116,6 @@ extension FeedViewController: UIScrollViewDelegate {
 // MARK: - detail feed model delegate
 extension FeedViewController: DetailFeedModelDelegate {
     func detailFeed(viewModel: DetailFeedViewModel) {
-        viewModel.update(start: self.viewModel.selected())
+        viewModel.fetchDetailFeedList(start: self.viewModel.selected())
     }
 }

--- a/Booster/Booster/ViewControllers/Feed/ModifyFeedViewController.swift
+++ b/Booster/Booster/ViewControllers/Feed/ModifyFeedViewController.swift
@@ -13,6 +13,7 @@ class ModifyFeedViewController: UIViewController, BaseViewControllerTemplate {
     // MARK: - @IBOutlet
 
     // MARK: - Properties
+    var viewModel = 0
 
     // MARK: - Subscript
 
@@ -21,11 +22,21 @@ class ModifyFeedViewController: UIViewController, BaseViewControllerTemplate {
     // MARK: - Life Cycles
     override func viewDidLoad() {
         super.viewDidLoad()
+
+        configure()
     }
-    
+
     // MARK: - @IBActions
 
     // MARK: - @objc
+    @objc private func completedButtonDidTapped(_ sender: UIBarButtonItem) {
+    }
 
     // MARK: - Functions
+    func configure() {
+        navigationItem.rightBarButtonItem = UIBarButtonItem(title: "완료",
+                                                            style: .done,
+                                                            target: self,
+                                                            action: #selector(completedButtonDidTapped(_:)))
+    }
 }

--- a/Booster/Booster/ViewControllers/Feed/ModifyFeedViewController.swift
+++ b/Booster/Booster/ViewControllers/Feed/ModifyFeedViewController.swift
@@ -1,0 +1,31 @@
+//
+//  ModifyFeedViewController.swift
+//  Booster
+//
+//  Created by hiju on 2021/11/17.
+//
+
+import UIKit
+
+class ModifyFeedViewController: UIViewController, BaseViewControllerTemplate {
+    // MARK: - Enum
+
+    // MARK: - @IBOutlet
+
+    // MARK: - Properties
+
+    // MARK: - Subscript
+
+    // MARK: - Init
+
+    // MARK: - Life Cycles
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+    
+    // MARK: - @IBActions
+
+    // MARK: - @objc
+
+    // MARK: - Functions
+}

--- a/Booster/Booster/ViewControllers/Home/HomeViewController.swift
+++ b/Booster/Booster/ViewControllers/Home/HomeViewController.swift
@@ -20,7 +20,7 @@ final class HomeViewController: UIViewController, BaseViewControllerTemplate {
     // MARK: - Properties
     var viewModel = HomeViewModel()
     private let disposeBag = DisposeBag()
-    private let todayHoursContant = 25
+    private let todayHoursContant = 24
 
     // MARK: - Life Cycles
     override func viewDidLoad() {
@@ -88,14 +88,7 @@ final class HomeViewController: UIViewController, BaseViewControllerTemplate {
 
     private func configureHourlyChartView() {
         let stepRatios: [CGFloat] = configureStepRatios(using: viewModel.homeModel.value.hourlyStatistics)
-        var strings = [String](repeating: "", count: todayHoursContant)
-        for (index, _) in strings.enumerated() {
-            if index % 6 == 0 {
-                strings[index] = "\(index)"
-            }
-        }
-
-        hourlyBarChartView.drawChart(stepRatios: stepRatios, strings: strings)
+        hourlyBarChartView.drawChart(stepRatios: stepRatios, strings: ["0", "6", "12", "18"])
     }
 
     private func configureStepRatios(using statisticsCollection: StatisticsCollection) -> [CGFloat] {

--- a/Booster/Booster/ViewModels/Feed/DetailFeedViewModel.swift
+++ b/Booster/Booster/ViewModels/Feed/DetailFeedViewModel.swift
@@ -8,20 +8,38 @@
 import Foundation
 
 final class DetailFeedViewModel {
+    // MARK: - Properties
     private let usecase: DetailFeedUsecase
     var trackingModel: BoosterObservable<TrackingModel>
 
+    // MARK: - Init
     init() {
         trackingModel = BoosterObservable(TrackingModel())
         usecase = DetailFeedUsecase()
     }
 
-    func update(start date: Date) {
+    // MARK: - Functions
+    func fetchDetailFeedList(start date: Date) {
         let predicate = NSPredicate(format: "startDate = %@", (date as NSDate) as CVarArg)
         usecase.fetch(predicate: predicate) { [weak self] result in
             if let model = result.first {
                 self?.trackingModel.value = model
             }
         }
+    }
+
+    func mileStone(at coordinate: Coordinate) -> MileStone? {
+        let target = trackingModel.value.milestones.first(where: { (value) in
+            return value.coordinate == coordinate
+        })
+
+        return target
+    }
+
+    func remove(of mileStone: MileStone) -> MileStone? {
+        guard let index = trackingModel.value.milestones.firstIndex(of: mileStone)
+        else { return nil }
+
+        return trackingModel.value.milestones.remove(at: index)
     }
 }

--- a/Booster/Booster/ViewModels/Feed/DetailFeedViewModel.swift
+++ b/Booster/Booster/ViewModels/Feed/DetailFeedViewModel.swift
@@ -9,10 +9,10 @@ import Foundation
 
 final class DetailFeedViewModel {
     private let usecase: DetailFeedUsecase
-    var trackingModel: Observable<TrackingModel>
+    var trackingModel: BoosterObservable<TrackingModel>
 
     init() {
-        trackingModel = Observable(TrackingModel())
+        trackingModel = BoosterObservable(TrackingModel())
         usecase = DetailFeedUsecase()
     }
 

--- a/Booster/Booster/ViewModels/Feed/FeedViewModel.swift
+++ b/Booster/Booster/ViewModels/Feed/FeedViewModel.swift
@@ -25,7 +25,7 @@ final class FeedViewModel {
                                         isEmpty: recordCount() == 0))
     }
 
-    private(set) var trackingRecords: Observable<[FeedList]>
+    private(set) var trackingRecords: BoosterObservable<[FeedList]>
     private var selectedIndex: IndexPath
     private var difference: Int
     private let usecase: FeedUseCase
@@ -34,7 +34,7 @@ final class FeedViewModel {
         difference = 0
         selectedIndex = IndexPath()
         usecase = FeedUseCase()
-        trackingRecords = Observable([])
+        trackingRecords = BoosterObservable([])
     }
 
     func recordCount() -> Int {

--- a/Booster/Booster/ViewModels/Home/HomeViewModel.swift
+++ b/Booster/Booster/ViewModels/Home/HomeViewModel.swift
@@ -6,72 +6,105 @@
 //
 import Foundation
 import HealthKit
+import RxSwift
+import RxRelay
 
 final class HomeViewModel {
     // MARK: - Properties
-    var homeModel: Observable<HomeModel> = Observable(HomeModel())
-
+    var homeModel = BehaviorRelay<HomeModel>(value: HomeModel())
     private let homeUsecase: HomeUsecase
+    private let disposeBag = DisposeBag()
 
     // MARK: - Init
     init() { self.homeUsecase = HomeUsecase() }
 
     // MARK: - Functions
     func fetchQueries() {
-        self.fetchTodayHourlyStepCountsData()
-        self.fetchTodayDistanceData()
-        self.fetchTodayKcalData()
-        self.fetchTodayTotalStepCountsData()
+        fetchTodayHourlyStepCountsData()
+        fetchTodayDistanceData()
+        fetchTodayKcalData()
+        fetchTodayTotalStepCountsData()
     }
 
     private func fetchTodayHourlyStepCountsData() {
-        homeUsecase.fetchHourlyStepCountsData { [weak self] statistics in
-            if let quantity = statistics.sumQuantity() {
-                let step = Int(quantity.doubleValue(for: HKUnit.count()))
-                let date = statistics.startDate
-                self?.addEmptyStatisticsIfNeeded(nowDate: date)
-                let entity = Statistics(date: date, step: step)
-                self?.homeModel.value.hourlyStatistics.append(statistics: entity)
+        homeUsecase.fetchHourlyStepCountsData()
+            .subscribe { [weak self] result in
+                guard let statistics = result.element,
+                      let entity = self?.convertHkStatisticsToCustomStatisticsOfStepCount(statistics)
+                else { return }
+
+                guard var newHomeModel = self?.homeModel.value
+                else { return }
+                newHomeModel.hourlyStatistics.append(statistics: entity)
+                self?.homeModel.accept(newHomeModel)
             }
-        }
+            .disposed(by: disposeBag)
     }
 
     private func fetchTodayDistanceData() {
-        homeUsecase.fetchTodayTotalData(type: .distanceWalkingRunning) { [weak self] result in
-            let distance = result.sumQuantity()?.doubleValue(for: HKUnit.meter()) ?? 0
-            let km = distance / 1000
-            self?.homeModel.value.km = km
-        }
+        homeUsecase.fetchTodayTotalData(type: .distanceWalkingRunning)
+            .subscribe { [weak self] result in
+                guard let statistics = result.element
+                else { return }
+
+                let distance = statistics.sumQuantity()?.doubleValue(for: HKUnit.meter()) ?? 0
+                let km = distance / 1000
+
+                guard var newHomeModel = self?.homeModel.value
+                else { return }
+                newHomeModel.km = km
+                self?.homeModel.accept(newHomeModel)
+            }
+            .disposed(by: disposeBag)
     }
 
     private func fetchTodayKcalData() {
-        homeUsecase.fetchTodayTotalData(type: .activeEnergyBurned) { [weak self] result in
-            let kcal = result.sumQuantity()?.doubleValue(for: HKUnit.kilocalorie()) ?? 0
-            self?.homeModel.value.kcal = Int(kcal)
-        }
+        homeUsecase.fetchTodayTotalData(type: .activeEnergyBurned)
+            .subscribe {[weak self] result in
+                guard let statistics = result.element
+                else { return }
+
+                let kcal = statistics.sumQuantity()?.doubleValue(for: HKUnit.kilocalorie()) ?? 0
+
+                guard var newHomeModel = self?.homeModel.value
+                else { return }
+                newHomeModel.kcal = Int(kcal)
+                self?.homeModel.accept(newHomeModel)
+
+            }
+            .disposed(by: disposeBag)
     }
 
     private func fetchTodayTotalStepCountsData() {
-        homeUsecase.fetchTodayTotalData(type: .stepCount) { [weak self] result in
-            guard let seconds = result.duration()?.doubleValue(for: .second()),
-                  let sum = result.sumQuantity()?.doubleValue(for: .count())
-            else { return }
+        homeUsecase.fetchTodayTotalData(type: .stepCount)
+            .subscribe { [weak self] result in
+                guard let statistics = result.element,
+                      let seconds = statistics.duration()?.doubleValue(for: .second()),
+                      let sum = statistics.sumQuantity()?.doubleValue(for: .count())
+                else { return }
 
-            self?.homeModel.value.activeTime = TimeInterval(seconds)
-            self?.homeModel.value.totalStepCount = Int(sum)
-        }
+                guard var newHomeModel = self?.homeModel.value
+                else { return }
+                newHomeModel.activeTime = TimeInterval(seconds)
+                newHomeModel.totalStepCount = Int(sum)
+                self?.homeModel.accept(newHomeModel)
+
+            }
+            .disposed(by: disposeBag)
     }
 
     private func addEmptyStatisticsIfNeeded(nowDate: Date) {
         let dateformatter = DateFormatter()
         dateformatter.dateFormat = "hh"
 
+        var newHomeModel = homeModel.value
         guard let lastStatisticsDate = homeModel.value.hourlyStatistics.statistics().last
         else {
             let nowHour = Int(dateformatter.string(from: nowDate)) ?? 0
             for _ in 0..<nowHour {
-                homeModel.value.hourlyStatistics.append(statistics: Statistics(date: Date(), step: 0))
+                newHomeModel.hourlyStatistics.append(statistics: Statistics(date: Date(), step: 0))
             }
+            homeModel.accept(newHomeModel)
             return
         }
 
@@ -82,8 +115,18 @@ final class HomeViewModel {
         if interval < 0 { interval += 12 }
         if interval > 1 {
             for _ in 0..<interval - 1 {
-                homeModel.value.hourlyStatistics.append(statistics: Statistics(date: Date(), step: 0))
+                newHomeModel.hourlyStatistics.append(statistics: Statistics(date: Date(), step: 0))
             }
         }
+        homeModel.accept(newHomeModel)
+    }
+
+    private func convertHkStatisticsToCustomStatisticsOfStepCount(_ statistics: HKStatistics) -> Statistics? {
+        guard let quantity = statistics.sumQuantity()
+        else { return nil }
+        let step = Int(quantity.doubleValue(for: HKUnit.count()))
+        let date = statistics.startDate
+        addEmptyStatisticsIfNeeded(nowDate: date)
+        return Statistics(date: date, step: step)
     }
 }

--- a/Booster/Booster/ViewModels/Statistic/StatisticsViewModel.swift
+++ b/Booster/Booster/ViewModels/Statistic/StatisticsViewModel.swift
@@ -12,8 +12,8 @@ final class StatisticsViewModel {
     private var monthStatistics = StatisticsCollection()
     private var yearStatistics  = StatisticsCollection()
 
-    var selectedDuration: Observable<Duration> = Observable(.week)
-    var selectedStatistics: Observable<(index: Int?, coordinate: Float?)> = Observable((nil, nil))
+    var selectedDuration: BoosterObservable<Duration> = BoosterObservable(.week)
+    var selectedStatistics: BoosterObservable<(index: Int?, coordinate: Float?)> = BoosterObservable((nil, nil))
 
     // MARK: - functions
     func statistics() -> StatisticsCollection {

--- a/Booster/Booster/ViewModels/Tracking/TrackingProgressViewModel.swift
+++ b/Booster/Booster/ViewModels/Tracking/TrackingProgressViewModel.swift
@@ -9,15 +9,15 @@ final class TrackingProgressViewModel {
     }
 
     private let trackingUsecase: TrackingProgressUsecase
-    private(set) var trackingModel: Observable<TrackingModel>
-    private(set) var milestones: Observable<[MileStone]>
+    private(set) var trackingModel: BoosterObservable<TrackingModel>
+    private(set) var milestones: BoosterObservable<[MileStone]>
     private(set) var user: UserInfo
     private(set) var state: TrackingState
 
     init(trackingModel: TrackingModel = TrackingModel(), user: UserInfo = UserInfo()) {
         trackingUsecase = TrackingProgressUsecase()
-        self.trackingModel = Observable(trackingModel)
-        self.milestones = Observable([MileStone]())
+        self.trackingModel = BoosterObservable(trackingModel)
+        self.milestones = BoosterObservable([MileStone]())
         self.user = user
         state = .start
     }

--- a/Booster/Booster/Views/Tracking/PhotoAnnotationView.swift
+++ b/Booster/Booster/Views/Tracking/PhotoAnnotationView.swift
@@ -1,7 +1,7 @@
 import UIKit
 import MapKit
 
-class PhotoAnnotationView: UIView {
+class PhotoAnnotationView: MKAnnotationView {
     @IBOutlet var backgroundView: UIView!
     @IBOutlet var photoImageView: UIImageView!
 


### PR DESCRIPTION
### 작업 내용
- detail feed 화면 코어 데이터 연동작업
- mapkit delegate 작성
- milstone 표시
- 설정 기능 (글 수정, 공유하기, 글 삭제) -> 각 메서드는 아직 구현하지 않았습니다.

### 체크리스트
- [x] detail feed 화면 코어 데이터 연동작업
- [x] mapkit delegate 작성
- [x] milstone 표시

### 구현 설명
- mapkit연동하고 코어데이터에서 정보 빼와서 화면에 뿌려주는 작업 완료
- 마일스톤 연동하긴했는데 아직 삭제부분이 미흡합니다. ;; (이유찾는중)

### 하고싶은 말
- 아직 완전히 다 구현하지 못해서 그점 양해부탁드립니다. (중간중간 메소드가 다 채워져 있진 않을거에요)
- 아키텍쳐는 아직 rx와 분리가 안되어 있어서 이부분도 양해부탁드려요!
- refac commit은 전단계 커밋이라, 여기서는 코드리뷰에서 refac 커밋은 빼시고 봐주세요 ! ㅎ