### PR TITLE
[E] 개인 설정 화면 버그 픽스

### DIFF
--- a/Booster/Booster/Extensions/UIAlertController+Extention.swift
+++ b/Booster/Booster/Extensions/UIAlertController+Extention.swift
@@ -1,13 +1,13 @@
 import UIKit
 
 extension UIAlertController {
-    static func simpleAlert(title: String, message msg: String) -> UIAlertController {
+    static func simpleAlert(title: String, message msg: String, action: ((UIAlertAction) -> Void)? = nil) -> UIAlertController {
         let alert = UIAlertController(title: title,
                                       message: msg,
                                       preferredStyle: .alert)
         alert.addAction(UIAlertAction(title: "확인",
                                       style: .default,
-                                      handler: .none))
+                                      handler: action))
 
         return alert
     }

--- a/Booster/Booster/Storyboards/User.storyboard
+++ b/Booster/Booster/Storyboards/User.storyboard
@@ -32,7 +32,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="XCD-IF-09o">
-                                <rect key="frame" x="0.0" y="88" width="414" height="725"/>
+                                <rect key="frame" x="0.0" y="44" width="414" height="769"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="psA-Kf-U6R">
@@ -57,6 +57,7 @@
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="qsR-Ob-qOH"/>
+                    <nil key="simulatedTopBarMetrics"/>
                     <simulatedTabBarMetrics key="simulatedBottomBarMetrics"/>
                     <connections>
                         <outlet property="userTableView" destination="XCD-IF-09o" id="euh-jb-cfN"/>
@@ -72,13 +73,13 @@
         <!--Erase All Data View Controller-->
         <scene sceneID="cua-w8-tPX">
             <objects>
-                <viewController storyboardIdentifier="EraseAllDataViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="gaz-xV-4fK" customClass="EraseAllDataViewController" customModule="Booster" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="EraseAllDataViewController" hidesBottomBarWhenPushed="YES" useStoryboardIdentifierAsRestorationIdentifier="YES" id="gaz-xV-4fK" customClass="EraseAllDataViewController" customModule="Booster" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="baM-Or-726">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="jtX-Va-dPj">
-                                <rect key="frame" x="25" y="118" width="175" height="109.5"/>
+                                <rect key="frame" x="25" y="74" width="175" height="109.5"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="아쉬워요" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="OdZ-V0-8i8">
                                         <rect key="frame" x="0.0" y="0.0" width="175" height="36.5"/>
@@ -101,13 +102,13 @@
                                 </subviews>
                             </stackView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="산책에 대한 기록들은..." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UtB-LM-UFO">
-                                <rect key="frame" x="25" y="237.5" width="364" height="22"/>
+                                <rect key="frame" x="25" y="193.5" width="364" height="22"/>
                                 <fontDescription key="fontDescription" name="NotoSansKR-Regular" family="Noto Sans KR" pointSize="15"/>
                                 <color key="textColor" name="boosterGray"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ozo-g4-J7M">
-                                <rect key="frame" x="25" y="632" width="364" height="46"/>
+                                <rect key="frame" x="25" y="681" width="364" height="46"/>
                                 <color key="backgroundColor" name="boosterOrange"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="46" id="kjT-2K-ZtJ"/>
@@ -173,13 +174,13 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="별명" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="RpI-2Q-lvm">
-                                <rect key="frame" x="25" y="128" width="364" height="22"/>
+                                <rect key="frame" x="25" y="84" width="364" height="22"/>
                                 <fontDescription key="fontDescription" name="NotoSansKR-Bold" family="Noto Sans KR" pointSize="15"/>
                                 <color key="textColor" name="boosterGray"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder=" " textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="7pw-cZ-Igf" customClass="EditUserInfoTextField" customModule="Booster" customModuleProvider="target">
-                                <rect key="frame" x="25" y="158" width="364" height="30.5"/>
+                                <rect key="frame" x="25" y="114" width="364" height="30.5"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="30.5" id="Z87-29-sTc"/>
                                 </constraints>
@@ -188,13 +189,13 @@
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="키" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZEf-np-hs6">
-                                <rect key="frame" x="25" y="198.5" width="364" height="22"/>
+                                <rect key="frame" x="25" y="154.5" width="364" height="22"/>
                                 <fontDescription key="fontDescription" name="NotoSansKR-Bold" family="Noto Sans KR" pointSize="15"/>
                                 <color key="textColor" name="boosterGray"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder=" " textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="pZT-3t-4Sp" customClass="EditUserInfoTextField" customModule="Booster" customModuleProvider="target">
-                                <rect key="frame" x="25" y="228.5" width="364" height="30.5"/>
+                                <rect key="frame" x="25" y="184.5" width="364" height="30.5"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="30.5" id="s6y-R5-Fim"/>
                                 </constraints>
@@ -203,13 +204,13 @@
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="몸무게" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jgP-4D-pdW">
-                                <rect key="frame" x="25" y="269" width="364" height="22"/>
+                                <rect key="frame" x="25" y="225" width="364" height="22"/>
                                 <fontDescription key="fontDescription" name="NotoSansKR-Bold" family="Noto Sans KR" pointSize="15"/>
                                 <color key="textColor" name="boosterGray"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder=" " textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="fBf-Mu-VWA" customClass="EditUserInfoTextField" customModule="Booster" customModuleProvider="target">
-                                <rect key="frame" x="25" y="299" width="364" height="30.5"/>
+                                <rect key="frame" x="25" y="255" width="364" height="30.5"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="30.5" id="d1v-Wh-nIT"/>
                                 </constraints>
@@ -218,13 +219,13 @@
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="나이" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="t7E-lB-x2X">
-                                <rect key="frame" x="25" y="339.5" width="364" height="22"/>
+                                <rect key="frame" x="25" y="295.5" width="364" height="22"/>
                                 <fontDescription key="fontDescription" name="NotoSansKR-Bold" family="Noto Sans KR" pointSize="15"/>
                                 <color key="textColor" name="boosterGray"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder=" " textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Egg-GA-zrJ" customClass="EditUserInfoTextField" customModule="Booster" customModuleProvider="target">
-                                <rect key="frame" x="25" y="369.5" width="364" height="30.5"/>
+                                <rect key="frame" x="25" y="325.5" width="364" height="30.5"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="30.5" id="CJ5-MR-nwZ"/>
                                 </constraints>
@@ -233,7 +234,7 @@
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="Stz-uY-Rct">
-                                <rect key="frame" x="25" y="440" width="364" height="46"/>
+                                <rect key="frame" x="25" y="396" width="364" height="46"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hU4-q3-XZt">
                                         <rect key="frame" x="0.0" y="0.0" width="172" height="46"/>
@@ -283,7 +284,7 @@
                                 </constraints>
                             </stackView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="성별" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="VjS-rT-0VE">
-                                <rect key="frame" x="25" y="410" width="364" height="22"/>
+                                <rect key="frame" x="25" y="366" width="364" height="22"/>
                                 <fontDescription key="fontDescription" name="NotoSansKR-Bold" family="Noto Sans KR" pointSize="15"/>
                                 <color key="textColor" name="boosterGray"/>
                                 <nil key="highlightedColor"/>
@@ -380,20 +381,21 @@
         <!--Change Goal View Controller-->
         <scene sceneID="m0S-ST-sqh">
             <objects>
-                <viewController storyboardIdentifier="ChangeGoalViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="K4L-eW-UsV" customClass="ChangeGoalViewController" customModule="Booster" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="ChangeGoalViewController" hidesBottomBarWhenPushed="YES" useStoryboardIdentifierAsRestorationIdentifier="YES" id="K4L-eW-UsV" customClass="ChangeGoalViewController" customModule="Booster" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="4JQ-dv-JaB">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="목표" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Pbg-5Z-gId">
-                                <rect key="frame" x="25" y="118" width="46" height="36.5"/>
+                                <rect key="frame" x="25" y="74" width="46" height="36.5"/>
                                 <fontDescription key="fontDescription" name="NotoSansKR-Medium" family="Noto Sans KR" pointSize="25"/>
                                 <color key="textColor" name="boosterLabel"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="eic-A8-vjy">
-                                <rect key="frame" x="55" y="244.5" width="304" height="73"/>
+                                <rect key="frame" x="55" y="200.5" width="304" height="73"/>
                                 <color key="backgroundColor" name="boosterBackground"/>
+                                <color key="tintColor" name="boosterOrange"/>
                                 <color key="textColor" name="boosterOrange"/>
                                 <fontDescription key="fontDescription" name="Bazaronite" family="Bazaronite" pointSize="60"/>
                                 <textInputTraits key="textInputTraits" keyboardType="numberPad"/>
@@ -431,10 +433,10 @@
                                         </fragment>
                                     </attributedString>
                                 </buttonConfiguration>
+                                <connections>
+                                    <action selector="saveButtonDidTap:" destination="K4L-eW-UsV" eventType="touchUpInside" id="LAO-qJ-BR2"/>
+                                </connections>
                             </button>
-                            <connections>
-                                <action selector="saveButtonDidTap:" destination="K4L-eW-UsV" id="dy9-RF-0i8"/>
-                            </connections>
                         </barButtonItem>
                     </navigationItem>
                     <connections>

--- a/Booster/Booster/Storyboards/User.storyboard
+++ b/Booster/Booster/Storyboards/User.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="LU8-Tb-h13">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="LU8-Tb-h13">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>

--- a/Booster/Booster/Storyboards/User.storyboard
+++ b/Booster/Booster/Storyboards/User.storyboard
@@ -168,7 +168,7 @@
         <!--Edit User Info View Controller-->
         <scene sceneID="kTX-en-9Ht">
             <objects>
-                <viewController storyboardIdentifier="EditUserInfoViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="Xp7-YD-aTC" customClass="EditUserInfoViewController" customModule="Booster" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="EditUserInfoViewController" hidesBottomBarWhenPushed="YES" useStoryboardIdentifierAsRestorationIdentifier="YES" id="Xp7-YD-aTC" customClass="EditUserInfoViewController" customModule="Booster" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="5gT-L0-AG4">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/Booster/Booster/ViewControllers/User/ChangeGoalViewController.swift
+++ b/Booster/Booster/ViewControllers/User/ChangeGoalViewController.swift
@@ -36,14 +36,16 @@ class ChangeGoalViewController: UIViewController, BaseViewControllerTemplate {
         if changeGoalValidator() {
 
         } else {
-            let alert = UIAlertController.simpleAlert(title: "변경 실패", message: "걸음 수가 빈칸 이거나 0인지 확인해주세요")
+            let title = "변경 실패"
+            let message = "걸음 수가 빈칸 이거나 0인지 확인해주세요"
+            let alert = UIAlertController.simpleAlert(title: title, message: message)
             present(alert, animated: true, completion: nil)
         }
     }
 
     // MARK: - Functions
     private func navigationBarTitleConfigure() {
-        title = "목표 바꾸기"
+        navigationItem.title = "목표 바꾸기"
     }
 
     private func configureUI() {

--- a/Booster/Booster/ViewControllers/User/ChangeGoalViewController.swift
+++ b/Booster/Booster/ViewControllers/User/ChangeGoalViewController.swift
@@ -22,7 +22,7 @@ class ChangeGoalViewController: UIViewController, BaseViewControllerTemplate {
 
         stepsTextField.delegate = self
 
-        navigationBarTitleConfigure()
+        configureNavigationBarTitle()
         configureUI()
         placeholderOfGoalTextField(steps: steps)
     }
@@ -44,7 +44,7 @@ class ChangeGoalViewController: UIViewController, BaseViewControllerTemplate {
     }
 
     // MARK: - Functions
-    private func navigationBarTitleConfigure() {
+    private func configureNavigationBarTitle() {
         navigationItem.title = "목표 바꾸기"
     }
 

--- a/Booster/Booster/ViewControllers/User/ChangeGoalViewController.swift
+++ b/Booster/Booster/ViewControllers/User/ChangeGoalViewController.swift
@@ -19,14 +19,12 @@ class ChangeGoalViewController: UIViewController, BaseViewControllerTemplate {
     // MARK: - Life Cycles
     override func viewDidLoad() {
         super.viewDidLoad()
-    }
-
-    override func viewWillAppear(_ animated: Bool) {
-        naivgationBarConfigure()
-        configureUI()
 
         stepsTextField.delegate = self
-        stepsTextField.becomeFirstResponder()
+
+        navigationBarTitleConfigure()
+        configureUI()
+        placeholderOfGoalTextField(steps: steps)
     }
 
     // MARK: - @IBActions
@@ -35,12 +33,17 @@ class ChangeGoalViewController: UIViewController, BaseViewControllerTemplate {
     }
 
     @IBAction private func saveButtonDidTap(_ sender: UIButton) {
+        if changeGoalValidator() {
 
+        } else {
+            let alert = UIAlertController.simpleAlert(title: "변경 실패", message: "걸음 수가 빈칸 이거나 0인지 확인해주세요")
+            present(alert, animated: true, completion: nil)
+        }
     }
 
     // MARK: - Functions
-    private func naivgationBarConfigure() {
-
+    private func navigationBarTitleConfigure() {
+        title = "목표 바꾸기"
     }
 
     private func configureUI() {
@@ -52,10 +55,38 @@ class ChangeGoalViewController: UIViewController, BaseViewControllerTemplate {
         stepsTextField.layer.addSublayer(border)
         stepsTextField.layer.masksToBounds = true
     }
+
+    private func placeholderOfGoalTextField(steps: Int) {
+        stepsTextField.clearsOnBeginEditing = true
+        stepsTextField.textColor = .boosterGray
+        stepsTextField.text = attributedTextOfcurrentGoal(steps: steps)
+    }
+
+    private func attributedTextOfcurrentGoal(steps: Int) -> String {
+        let attributedString = NSAttributedString(string: "\(steps)", attributes: [.foregroundColor: UIColor.boosterGray])
+
+        return attributedString.string
+    }
+
+    private func changeGoalValidator() -> Bool {
+        guard let stepsText = stepsTextField.text,
+              let steps = Int(stepsText)
+        else { return false }
+
+        if steps == 0 { return false }
+
+        return true
+    }
 }
 
 // MARK: - UITextFieldDelegate
 extension ChangeGoalViewController: UITextFieldDelegate {
+    func textFieldShouldBeginEditing(_ textField: UITextField) -> Bool {
+        stepsTextField.textColor = .boosterOrange
+
+        return true
+    }
+
     func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
         guard let text = textField.text
         else { return true }

--- a/Booster/Booster/ViewControllers/User/EditUserInfoViewController.swift
+++ b/Booster/Booster/ViewControllers/User/EditUserInfoViewController.swift
@@ -125,7 +125,7 @@ final class EditUserInfoViewController: UIViewController, BaseViewControllerTemp
 
     // MARK: - Functions
     private func navigationBarTitleConfigure() {
-        title = "개인 정보 수정"
+        navigationItem.title = "개인 정보 수정"
     }
 
     private func saveEditedUserInfo(gender: String,

--- a/Booster/Booster/ViewControllers/User/EditUserInfoViewController.swift
+++ b/Booster/Booster/ViewControllers/User/EditUserInfoViewController.swift
@@ -91,6 +91,7 @@ final class EditUserInfoViewController: UIViewController, BaseViewControllerTemp
 
         configureUIButton()
         configureUITextField()
+        loadUserInfoToView()
     }
 
     // MARK: - @IBActions
@@ -141,21 +142,24 @@ final class EditUserInfoViewController: UIViewController, BaseViewControllerTemp
             DispatchQueue.main.async {
                 var alert = UIAlertController()
                 if isSaved {
-                    alert = UIAlertController.simpleAlert(title: "", message: "수정 완료")
+                    alert = UIAlertController.simpleAlert(title: "",
+                                                          message: "수정 완료",
+                                                          action: { (_) -> Void in
+                        self?.navigationController?.popViewController(animated: true)
+                        return
+                    })
                 } else {
                     alert = UIAlertController.simpleAlert(title: "", message: "수정 실패")
                 }
-                self?.present(alert, animated: true) {
-                    self?.navigationController?.popViewController(animated: true)
-                    dump(self?.viewModel)
-                }
+                self?.present(alert, animated: true)
+                dump(self?.viewModel)
             }
         }
     }
 
     private func configureUIButton() {
-        femaleGenderButton.isEnabled = false
         maleGenderButton.isEnabled = true
+        femaleGenderButton.isEnabled = true
 
         maleGenderButton.setBackgroundColor(color: .boosterOrange, for: .disabled)
         maleGenderButton.setBackgroundColor(color: .boosterEnableButtonGray, for: .normal)
@@ -174,5 +178,16 @@ final class EditUserInfoViewController: UIViewController, BaseViewControllerTemp
         heightTextField.resignFirstResponder()
         weightTextField.resignFirstResponder()
         ageTextField.resignFirstResponder()
+    }
+
+    private func loadUserInfoToView() {
+        if let gender = genderButtonType(rawValue: viewModel.model.gender) {
+            (gender == .male) ? (maleGenderButton.isEnabled = false) : (femaleGenderButton.isEnabled = false)
+        }
+
+        nickNameTextField.text = viewModel.model.nickname
+        heightTextField.text = "\(viewModel.model.height)"
+        weightTextField.text = "\(viewModel.model.weight)"
+        ageTextField.text = "\(viewModel.model.age)"
     }
 }

--- a/Booster/Booster/ViewControllers/User/EditUserInfoViewController.swift
+++ b/Booster/Booster/ViewControllers/User/EditUserInfoViewController.swift
@@ -89,6 +89,7 @@ final class EditUserInfoViewController: UIViewController, BaseViewControllerTemp
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        navigationBarTitleConfigure()
         configureUIButton()
         configureUITextField()
         loadUserInfoToView()
@@ -123,6 +124,10 @@ final class EditUserInfoViewController: UIViewController, BaseViewControllerTemp
     }
 
     // MARK: - Functions
+    private func navigationBarTitleConfigure() {
+        title = "개인 정보 수정"
+    }
+
     private func saveEditedUserInfo(gender: String,
                                     age: String,
                                     height: String,

--- a/Booster/Booster/ViewControllers/User/EditUserInfoViewController.swift
+++ b/Booster/Booster/ViewControllers/User/EditUserInfoViewController.swift
@@ -89,7 +89,7 @@ final class EditUserInfoViewController: UIViewController, BaseViewControllerTemp
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        navigationBarTitleConfigure()
+        configureNavigationBarTitle()
         configureUIButton()
         configureUITextField()
         loadUserInfoToView()
@@ -124,7 +124,7 @@ final class EditUserInfoViewController: UIViewController, BaseViewControllerTemp
     }
 
     // MARK: - Functions
-    private func navigationBarTitleConfigure() {
+    private func configureNavigationBarTitle() {
         navigationItem.title = "개인 정보 수정"
     }
 

--- a/Booster/Booster/ViewControllers/User/EraseAllDataViewController.swift
+++ b/Booster/Booster/ViewControllers/User/EraseAllDataViewController.swift
@@ -32,8 +32,13 @@ final class EraseAllDataViewController: UIViewController, BaseViewControllerTemp
                 switch result {
                 case .success(let count):
                     let title = "삭제 완료"
-                    let message = "총 \(count)개의 정보가 삭제됐어요!"
-                    alert = UIAlertController.simpleAlert(title: title, message: message)
+                    let message = "모든 정보가 삭제됐어요!"
+                    alert = UIAlertController.simpleAlert(title: title,
+                                                          message: message,
+                                                          action: { (_) -> Void in
+                        self?.navigationController?.popViewController(animated: true)
+                        return
+                    })
                 case .failure(let error):
                     dump(error)
                     let title = "삭제 실패"

--- a/Booster/Booster/ViewControllers/User/EraseAllDataViewController.swift
+++ b/Booster/Booster/ViewControllers/User/EraseAllDataViewController.swift
@@ -20,7 +20,7 @@ final class EraseAllDataViewController: UIViewController, BaseViewControllerTemp
     }
 
     override func viewWillAppear(_ animated: Bool) {
-        naivgationBarConfigure()
+        navigationBarTitleConfigure()
         configureUI()
     }
 
@@ -52,8 +52,8 @@ final class EraseAllDataViewController: UIViewController, BaseViewControllerTemp
     }
 
     // MARK: - Functions
-    private func naivgationBarConfigure() {
-
+    private func navigationBarTitleConfigure() {
+        title = "모든 데이터 지우기"
     }
 
     private func configureUI() {

--- a/Booster/Booster/ViewControllers/User/EraseAllDataViewController.swift
+++ b/Booster/Booster/ViewControllers/User/EraseAllDataViewController.swift
@@ -20,7 +20,7 @@ final class EraseAllDataViewController: UIViewController, BaseViewControllerTemp
     }
 
     override func viewWillAppear(_ animated: Bool) {
-        navigationBarTitleConfigure()
+        configureNavigationBarTitle()
         configureUI()
     }
 
@@ -40,7 +40,6 @@ final class EraseAllDataViewController: UIViewController, BaseViewControllerTemp
                         return
                     })
                 case .failure(let error):
-                    dump(error)
                     let title = "삭제 실패"
                     let message = "알 수 없는 오류로 인하여 정보를 삭제할 수 없어요"
                     alert = UIAlertController.simpleAlert(title: title, message: message)
@@ -57,7 +56,7 @@ final class EraseAllDataViewController: UIViewController, BaseViewControllerTemp
     }
 
     // MARK: - Functions
-    private func navigationBarTitleConfigure() {
+    private func configureNavigationBarTitle() {
         navigationItem.title = "모든 데이터 지우기"
     }
 

--- a/Booster/Booster/ViewControllers/User/EraseAllDataViewController.swift
+++ b/Booster/Booster/ViewControllers/User/EraseAllDataViewController.swift
@@ -57,6 +57,6 @@ final class EraseAllDataViewController: UIViewController, BaseViewControllerTemp
     }
 
     private func configureUI() {
-        subTitleLabel.text = "산책에 대한 기록들은 \(viewModel.nickname())님의\n휴대폰에서만 소중하게 보관하고 있어요"
+        subTitleLabel.text = "산책에 대한 기록들은 \(viewModel.model.nickname)님의\n휴대폰에서만 소중하게 보관하고 있어요"
     }
 }

--- a/Booster/Booster/ViewControllers/User/EraseAllDataViewController.swift
+++ b/Booster/Booster/ViewControllers/User/EraseAllDataViewController.swift
@@ -58,7 +58,7 @@ final class EraseAllDataViewController: UIViewController, BaseViewControllerTemp
 
     // MARK: - Functions
     private func navigationBarTitleConfigure() {
-        title = "모든 데이터 지우기"
+        navigationItem.title = "모든 데이터 지우기"
     }
 
     private func configureUI() {

--- a/Booster/Booster/ViewControllers/User/UserViewController.swift
+++ b/Booster/Booster/ViewControllers/User/UserViewController.swift
@@ -47,6 +47,12 @@ final class UserViewController: UIViewController, BaseViewControllerTemplate {
 
     override func viewWillAppear(_ animated: Bool) {
         userTableView.reloadData()
+        navigationController?.navigationBar.isHidden = true
+        title = ""
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        navigationController?.navigationBar.isHidden = false
     }
 
     // MARK: - Functions
@@ -54,6 +60,12 @@ final class UserViewController: UIViewController, BaseViewControllerTemplate {
         userTableView.register(UINib(nibName: UserInfoHeaderView.identifier, bundle: nil), forHeaderFooterViewReuseIdentifier: UserInfoHeaderView.identifier)
         userTableView.register(UINib(nibName: MyInfoHeaderView.identifier, bundle: nil), forHeaderFooterViewReuseIdentifier: MyInfoHeaderView.identifier)
         userTableView.register(UINib(nibName: UserInfoBaseCell.identifier, bundle: nil), forCellReuseIdentifier: UserInfoBaseCell.identifier)
+    }
+
+    private func navigationBarTitleConfigure() {
+        let attribute = [NSAttributedString.Key.font: UIFont.notoSansKR(.light, 18)]
+
+        navigationController?.navigationBar.titleTextAttributes = attribute
     }
 
     private func myInfoCellDidSelectActions(cellType: MyInfoCellType) {

--- a/Booster/Booster/ViewControllers/User/UserViewController.swift
+++ b/Booster/Booster/ViewControllers/User/UserViewController.swift
@@ -48,7 +48,7 @@ final class UserViewController: UIViewController, BaseViewControllerTemplate {
     override func viewWillAppear(_ animated: Bool) {
         userTableView.reloadData()
         navigationController?.navigationBar.isHidden = true
-        title = ""
+        navigationItem.title = ""
     }
 
     override func viewWillDisappear(_ animated: Bool) {
@@ -92,7 +92,9 @@ final class UserViewController: UIViewController, BaseViewControllerTemplate {
         case .notificationSetting:
             guard let url = URL(string: UIApplication.openSettingsURLString)
             else {
-                let alert = UIAlertController.simpleAlert(title: "오류", message: "알 수 없는 오류로 인하여 알람 설정을 할 수 없어요")
+                let title = "오류"
+                let message = "알 수 없는 오류로 인하여 알람 설정을 할 수 없어요"
+                let alert = UIAlertController.simpleAlert(title: title, message: message)
                 present(alert, animated: true, completion: nil)
 
                 return

--- a/Booster/Booster/ViewControllers/User/UserViewController.swift
+++ b/Booster/Booster/ViewControllers/User/UserViewController.swift
@@ -43,6 +43,7 @@ final class UserViewController: UIViewController, BaseViewControllerTemplate {
         userTableView.dataSource = self
         userTableView.delegate = self
         registerNib()
+        configureNavigationBarTitle()
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -62,7 +63,7 @@ final class UserViewController: UIViewController, BaseViewControllerTemplate {
         userTableView.register(UINib(nibName: UserInfoBaseCell.identifier, bundle: nil), forCellReuseIdentifier: UserInfoBaseCell.identifier)
     }
 
-    private func navigationBarTitleConfigure() {
+    private func configureNavigationBarTitle() {
         let attribute = [NSAttributedString.Key.font: UIFont.notoSansKR(.light, 18)]
 
         navigationController?.navigationBar.titleTextAttributes = attribute

--- a/Booster/Booster/ViewModels/User/UserViewModel.swift
+++ b/Booster/Booster/ViewModels/User/UserViewModel.swift
@@ -13,15 +13,11 @@ final class UserViewModel {
     }
 
     private let usecase: UserUsecase
-    private var model: UserInfo
+    private(set) var model: UserInfo
 
     init() {
         usecase = UserUsecase()
         model = UserInfo(age: 25, nickname: "히로롱", gender: "여", height: 164, weight: 80)
-    }
-
-    func nickname() -> String {
-        return model.nickname
     }
 
     func userPhysicalInfo() -> String {

--- a/Booster/Booster/Views/User/EditUserInfoTextField.swift
+++ b/Booster/Booster/Views/User/EditUserInfoTextField.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class EditUserInfoTextField: UITextField {
+final class EditUserInfoTextField: UITextField {
     override init(frame: CGRect) {
         super.init(frame: frame)
 
@@ -20,7 +20,7 @@ class EditUserInfoTextField: UITextField {
         commonInit()
     }
 
-    func commonInit() {
+    private func commonInit() {
         let border = CALayer()
         border.frame = CGRect(x: 0, y: frame.height - 1, width: frame.width, height: 1)
         border.backgroundColor = UIColor.boosterGray.cgColor

--- a/Booster/Booster/Views/User/UserInfoHeaderView.swift
+++ b/Booster/Booster/Views/User/UserInfoHeaderView.swift
@@ -12,7 +12,7 @@ final class UserInfoHeaderView: UITableViewHeaderFooterView {
     @IBOutlet private weak var userInfoLabel: UILabel!
 
     func configure(viewModel: UserViewModel) {
-        nicknameLabel.text = viewModel.nickname()
+        nicknameLabel.text = viewModel.model.nickname
         userInfoLabel.text = viewModel.userPhysicalInfo()
     }
 }


### PR DESCRIPTION
### 작업 내용
[E-89] 목표바꾸기 페이지 내 기존 목표 값 표기
[E-80] 마이페이지 내 기존 값 표기
UIAlertController+Extenstion 내부에 simpleAlert에 새로운 파라미터 추가
### 체크리스트
- [x] #128 버그 픽스
- [x] #129 버그 픽스
- [x] NavigationBar Title 제대로 표시 되지 않는 현상 수정
- [x] UIAlertController 이후 VC가 Pop 되지 않는 현상 수정

### 구현 설명
- UIAlertController+Extenstion 내부에 simpleAlert에 새로운 파라미터 추가
확인 버튼에 대한 action Closure를 받을 수 있도록 추가. default 값 nil을 통하여 기존 코드에 지장 없도록 구현
사용법
~~~swift
alert = UIAlertController.simpleAlert(title: title,
                                                              message: message,
                                                              action: { (_) -> Void in
                            self?.navigationController?.popViewController(animated: true)
                            return
})
~~~
### 하고싶은 말
스크린샷에는 탭바가 표시 되는데 실제로는 표시 되지 않도록 수정했어요!!
<img src=https://user-images.githubusercontent.com/48645631/142724012-1e9f8d5a-fa0a-4627-ab68-07531ca99050.png width = "280"> <img src=https://user-images.githubusercontent.com/48645631/142724020-dbdcdeae-43ea-4457-a15e-dcb174e4bdd8.png width = "280">
