### PR TITLE
[D] 버그 수정 및 리팩토링 때 누락된 코드 추가 #134

### DIFF
--- a/Booster/Booster/Repositories/CoreDataManager.swift
+++ b/Booster/Booster/Repositories/CoreDataManager.swift
@@ -94,8 +94,8 @@ final class CoreDataManager {
     func fetch<DataType: NSManagedObject>() -> Observable<[DataType]> {
         return Observable.create { [weak self] observer in
             guard let self = self
-            else { return }
-            
+            else { return Disposables.create() }
+
             let backgroundContext = self.container.newBackgroundContext()
 
             backgroundContext.perform {

--- a/Booster/Booster/ViewModels/Tracking/TrackingProgressViewModel.swift
+++ b/Booster/Booster/ViewModels/Tracking/TrackingProgressViewModel.swift
@@ -165,6 +165,17 @@ final class TrackingProgressViewModel {
                                  unit: .calorie)
         }.disposed(by: disposeBag)
 
+        state.filter {
+            $0 == .pause
+        }.bind { [weak self] _ in
+            guard let self = self
+            else { return }
+
+            var tracking = self.tracking.value
+            tracking.coordinates.append(Coordinate(latitude: nil, longitude: nil))
+            self.tracking.accept(tracking)
+        }.disposed(by: disposeBag)
+
         title.bind { [weak self] value in
             guard let self = self
             else { return }

--- a/Booster/Booster/Views/Tracking/TrackingMapView.swift
+++ b/Booster/Booster/Views/Tracking/TrackingMapView.swift
@@ -108,6 +108,7 @@ class TrackingMapView: MKMapView {
 
             context.setLineWidth(pathLineWidth)
             context.setStrokeColor(UIColor.boosterOrange.cgColor)
+            context.setLineCap(.round)
 
             var prevCoordinate: Coordinate? = self?.startCoordinate(coordinates: coordinates)
             guard let startLatitude = prevCoordinate?.latitude,


### PR DESCRIPTION
### 작업 내용
TrackingViewModel을 Rx 바인드 코드로 리팩토링 하면서 일시정지 시 Coordinates에 nil이 들어가던 로직이 누락된 것 반영
snapShotImageOfPath로 피드에 사용할 이미지를 가공하던 중 경로가 부드럽게 이어지지 않게 표시되는 현상 수정
### 체크리스트
- [x] #134 버그 픽스
- [x]  snapShotImageOfPath의 경로 결과 이미지 수정

### 구현 설명
bind 코드에 `state == .pause` 상태일 시 Coordinate(nil, nil)을 추가하는 코드 추가
https://developer.apple.com/documentation/quartzcore/cashapelayer/1521905-linecap
### 하고싶은 말
