### PR TITLE
[A] 홈뷰컨 리팩토링

### DIFF
--- a/Booster/Booster.xcodeproj/project.pbxproj
+++ b/Booster/Booster.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		37852ACF273C27F100BA3D67 /* StatisticsModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37852ACE273C27F100BA3D67 /* StatisticsModelTests.swift */; };
 		37852AD8273C2D0B00BA3D67 /* StepStatisticsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37852AD7273C2D0B00BA3D67 /* StepStatisticsTests.swift */; };
 		379E3C57273BC182002B0B15 /* ChartView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 379E3C56273BC182002B0B15 /* ChartView.swift */; };
+		37AE2EA8274F5401003F5FF7 /* GradientLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37AE2EA7274F5401003F5FF7 /* GradientLabel.swift */; };
 		37FD1AEE274D1D6600FAB0CC /* HealthKitManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37FD1AED274D1D6600FAB0CC /* HealthKitManager.swift */; };
 		3B31B5F9273C05D8009D9190 /* FeedCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B31B5F8273C05D8009D9190 /* FeedCell.swift */; };
 		3B31B5FC273C0A66009D9190 /* CellConfigurator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B31B5FB273C0A66009D9190 /* CellConfigurator.swift */; };
@@ -164,6 +165,7 @@
 		37852ACE273C27F100BA3D67 /* StatisticsModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatisticsModelTests.swift; sourceTree = "<group>"; };
 		37852AD7273C2D0B00BA3D67 /* StepStatisticsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StepStatisticsTests.swift; sourceTree = "<group>"; };
 		379E3C56273BC182002B0B15 /* ChartView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChartView.swift; sourceTree = "<group>"; };
+		37AE2EA7274F5401003F5FF7 /* GradientLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GradientLabel.swift; sourceTree = "<group>"; };
 		37FD1AED274D1D6600FAB0CC /* HealthKitManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthKitManager.swift; sourceTree = "<group>"; };
 		3B31B5F8273C05D8009D9190 /* FeedCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedCell.swift; sourceTree = "<group>"; };
 		3B31B5FB273C0A66009D9190 /* CellConfigurator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CellConfigurator.swift; sourceTree = "<group>"; };
@@ -534,6 +536,7 @@
 		FA473A1B273BA2130000C5DC /* Home */ = {
 			isa = PBXGroup;
 			children = (
+				37AE2EA7274F5401003F5FF7 /* GradientLabel.swift */,
 			);
 			path = Home;
 			sourceTree = "<group>";
@@ -1024,6 +1027,7 @@
 				FA614F812733CDAA00B090D9 /* TrackingViewController.swift in Sources */,
 				3B31B5FF273CD2F7009D9190 /* Tracking+CoreDataClass.swift in Sources */,
 				28C96FED27396F6B005BD7BC /* DetailFeedViewModel.swift in Sources */,
+				37AE2EA8274F5401003F5FF7 /* GradientLabel.swift in Sources */,
 				FA614F6D2733CDAA00B090D9 /* User+CoreDataClass.swift in Sources */,
 				3B6FE5002743A5F400A815D1 /* EnrollWriteView.swift in Sources */,
 				3BE60F6427464E0300B4EFB8 /* StepStatitstics.swift in Sources */,

--- a/Booster/Booster/Models/HomeModel.swift
+++ b/Booster/Booster/Models/HomeModel.swift
@@ -30,4 +30,8 @@ struct HomeModel {
 
         return (Double(totalStepCount) / Double(goal))
     }
+    
+    func stepRatios() -> [Float]? {
+        hourlyStatistics.stepRatios()
+    }
 }

--- a/Booster/Booster/Models/HomeModel.swift
+++ b/Booster/Booster/Models/HomeModel.swift
@@ -1,5 +1,5 @@
 //
-//  HomeData.swift
+//  HomeModel.swift
 //  Booster
 //
 //  Created by hiju on 2021/11/03.
@@ -19,8 +19,15 @@ struct HomeModel {
         kcal = 0
         km = 0.0
         activeTime = 0
-        goal = 0
+        goal = 10000
         totalStepCount = 0
         hourlyStatistics = StepStatisticsCollection()
+    }
+
+    func gradientRatio() -> Double {
+        guard goal > 0
+        else { return Double(0) }
+
+        return (Double(totalStepCount) / Double(goal))
     }
 }

--- a/Booster/Booster/Services/HealthKitManager.swift
+++ b/Booster/Booster/Services/HealthKitManager.swift
@@ -91,15 +91,13 @@ final class HealthKitManager {
         }
     }
 
-    func requestStatisticsQuery(type: HKQuantityType, predicate: NSPredicate) -> Observable<HKStatistics> {
+    func requestStatisticsQuery(type: HKQuantityType, predicate: NSPredicate) -> Observable<HKStatistics?> {
         return Observable.create { [weak self] observer in
             let query = HKStatisticsQuery(
                 quantityType: type,
                 quantitySamplePredicate: predicate,
                 options: [.cumulativeSum, .duration]) { _, statistics, _ in
-                if let statistics = statistics {
-                    return observer.onNext(statistics)
-                }
+                return observer.onNext(statistics)
             }
 
             self?.healthStore?.execute(query)

--- a/Booster/Booster/Storyboards/Home.storyboard
+++ b/Booster/Booster/Storyboards/Home.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Y6W-OH-hqX">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Y6W-OH-hqX">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -46,7 +46,7 @@
                                 <color key="textColor" name="boosterLabel"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ssn-6d-STD">
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ssn-6d-STD" customClass="GradientLabel" customModule="Booster" customModuleProvider="target">
                                 <rect key="frame" x="182" y="343.5" width="66.5" height="119"/>
                                 <fontDescription key="fontDescription" name="Bazaronite" family="Bazaronite" pointSize="100"/>
                                 <color key="textColor" name="boosterLabel"/>

--- a/Booster/Booster/Usecases/HomeUsecase.swift
+++ b/Booster/Booster/Usecases/HomeUsecase.swift
@@ -17,7 +17,9 @@ final class HomeUsecase {
             let anchorDate = Calendar.current.startOfDay(for: Date())
             guard let self = self,
                   let stepCountSampleType = HKSampleType.quantityType(forIdentifier: .stepCount),
-                  let endDate = Calendar.current.date(byAdding: .hour, value: 23, to: anchorDate)
+                  let endDate = Calendar.current.date(byAdding: .hour,
+                                                      value: 23,
+                                                      to: anchorDate)
             else { return Disposables.create() }
 
             let predicate = HKQuery.predicateForSamples(withStart: anchorDate,

--- a/Booster/Booster/Usecases/HomeUsecase.swift
+++ b/Booster/Booster/Usecases/HomeUsecase.swift
@@ -12,37 +12,57 @@ import RxSwift
 final class HomeUsecase {
     private let disposeBag = DisposeBag()
 
-    func fetchHourlyStepCountsData() -> Observable<HKStatistics> {
+    func fetchHourlyStepCountsData() -> Observable<StepStatisticsCollection> {
         return Observable.create { [weak self] observer in
+            let anchorDate = Calendar.current.startOfDay(for: Date())
             guard let self = self,
                   let stepCountSampleType = HKSampleType.quantityType(forIdentifier: .stepCount),
-                  let anchorDate = Calendar.current.date(bySettingHour: 0,
-                                                         minute: 0,
-                                                         second: 0,
-                                                         of: Date()),
-                  let now = Calendar.current.date(byAdding: .hour, value: 23, to: anchorDate)
+                  let endDate = Calendar.current.date(byAdding: .hour, value: 23, to: anchorDate)
             else { return Disposables.create() }
 
             let predicate = HKQuery.predicateForSamples(withStart: anchorDate,
-                                                        end: now,
+                                                        end: endDate,
                                                         options: .strictStartDate)
+
             let observable = HealthKitManager.shared.requestStatisticsCollectionQuery(type: stepCountSampleType,
                                                                        predicate: predicate,
                                                                        interval: DateComponents(hour: 1),
                                                                        anchorDate: anchorDate)
+
             observable.subscribe { hkStatisticsCollection in
-                hkStatisticsCollection.enumerateStatistics(from: Calendar.current.startOfDay(for: now),
-                                                           to: now,
-                                                           with: { statistics, _ in
-                    observer.onNext(statistics)
+                guard let hkStatisticsCollection = hkStatisticsCollection.element
+                else { return }
+
+                var stepStatisticsCollection = StepStatisticsCollection()
+
+                hkStatisticsCollection.enumerateStatistics(from: anchorDate,
+                                                           to: endDate,
+                                                           with: { hkstatistics, _ in
+
+                    let step = Int(hkstatistics.sumQuantity()?.doubleValue(for: .count()) ?? 0)
+                    let date = hkstatistics.startDate
+                    let stepStatistics = self.configureStepStatistics(step: step, date: date)
+                    stepStatisticsCollection.append(stepStatistics)
                 })
+
+                observer.onNext(stepStatisticsCollection)
             }.disposed(by: self.disposeBag)
 
             return Disposables.create()
         }
     }
 
-    func fetchTodayTotalData(type: HKQuantityTypeIdentifier) -> Observable<HKStatistics> {
+    private func configureStepStatistics(step: Int, date: Date) -> StepStatistics {
+        let dateFormatter = DateFormatter()
+        dateFormatter.locale = Locale(identifier: "ko_KR")
+        dateFormatter.dateFormat = "H"
+
+        let string = dateFormatter.string(from: date)
+
+        return StepStatistics(step: step, abbreviatedDateString: string)
+    }
+
+    func fetchTodayTotalData(type: HKQuantityTypeIdentifier) -> Observable<HKStatistics?> {
         return Observable.create { [weak self] observer in
             guard let self = self,
                   let sampleType = HKSampleType.quantityType(forIdentifier: type)
@@ -54,8 +74,9 @@ final class HomeUsecase {
                                                         end: now,
                                                         options: .strictStartDate)
 
-            HealthKitManager.shared.requestStatisticsQuery(type: sampleType, predicate: predicate).subscribe { result in
-                observer.onNext(result)
+            let observable = HealthKitManager.shared.requestStatisticsQuery(type: sampleType, predicate: predicate)
+            observable.subscribe { result in
+               observer.onNext(result)
             }.disposed(by: self.disposeBag)
 
             return Disposables.create()

--- a/Booster/Booster/ViewControllers/Home/HomeViewController.swift
+++ b/Booster/Booster/ViewControllers/Home/HomeViewController.swift
@@ -1,27 +1,20 @@
 import HealthKit
 import UIKit
+
 import RxSwift
 
-final class HomeViewController: UIViewController, BaseViewControllerTemplate {
-    // MARK: - Enum
-    private enum Opacity {
-        static let zero: Float = 0
-        static let one: Float = 1
-    }
-
+final class HomeViewController: UIViewController {
     // MARK: - @IBOutlet
     @IBOutlet private weak var kcalLabel: UILabel!
     @IBOutlet private weak var timeActiveLabel: UILabel!
     @IBOutlet private weak var kmLabel: UILabel!
-    @IBOutlet private weak var todayTotalStepCountLabel: UILabel!
+    @IBOutlet private weak var todayTotalStepCountLabel: GradientLabel!
     @IBOutlet private weak var goalLabel: UILabel!
     @IBOutlet private weak var hourlyBarChartView: ChartView!
 
     // MARK: - Properties
     private let disposeBag = DisposeBag()
-    private let todayHoursContant = 24
-
-    var viewModel = HomeViewModel()
+    private let viewModel = HomeViewModel()
 
     // MARK: - Life Cycles
     override func viewDidLoad() {
@@ -52,39 +45,24 @@ final class HomeViewController: UIViewController, BaseViewControllerTemplate {
         }
     }
 
-    private func configureTotalStepCountLabelGradient(current: Double, goal: Double) {
-        let labelSize = 70.0
-        let ratio = (current * labelSize / goal) / 100 + 0.25
-        let gradient = gradientLayer(ratio: [NSNumber(value: ratio), NSNumber(value: ratio)],
-                                     bounds: todayTotalStepCountLabel.bounds,
-                                     colors: [UIColor.boosterOrange.cgColor, UIColor.boosterLabel.cgColor])
-        todayTotalStepCountLabel.textColor = gradientColor(gradientLayer: gradient)
-    }
-
     private func bindHomeViewModel() {
         viewModel.homeModel
             .debounce(RxTimeInterval.milliseconds(100), scheduler: MainScheduler.instance)
-            .subscribe({ [weak self] value in
-                guard let model = value.element
+            .subscribe({ [weak self] homeModel in
+                guard let homeModel = homeModel.element
                 else { return }
-
-                self?.configureLabels(model)
+                self?.updateUI(using: homeModel)
             })
             .disposed(by: disposeBag)
     }
 
-    private func configureLabels(_ value: HomeModel) {
-        todayTotalStepCountLabel.text = "\(value.totalStepCount)"
-        kmLabel.text = String(format: "%.2f", value.km)
-        kcalLabel.text = "\(value.kcal)"
-        timeActiveLabel.text = value.activeTime.stringToMinutesAndSeconds()
-        todayTotalStepCountLabel.layer.opacity = Opacity.zero
-        configureTotalStepCountLabelGradient(current: Double(value.totalStepCount), goal: 10000)
+    private func updateUI(using homeModel: HomeModel) {
+        kmLabel.text = String(format: "%.2f", homeModel.km)
+        kcalLabel.text = "\(homeModel.kcal)"
+        timeActiveLabel.text = homeModel.activeTime.stringToMinutesAndSeconds()
         configureHourlyChartView()
-
-        UIView.animate(withDuration: 2) {
-            self.todayTotalStepCountLabel.layer.opacity = Opacity.one
-        }
+        todayTotalStepCountLabel.drawLabel(step: homeModel.totalStepCount,
+                                           ratio: homeModel.gradientRatio())
     }
 
     private func configureHourlyChartView() {
@@ -92,29 +70,5 @@ final class HomeViewController: UIViewController, BaseViewControllerTemplate {
         else { return }
 
         hourlyBarChartView.drawChart(stepRatios: stepRatios.map { CGFloat($0) }, strings: ["0", "6", "12", "18"])
-    }
-
-    private func gradientLayer(ratio: [NSNumber],
-                               bounds: CGRect,
-                               colors: [CGColor]) -> CAGradientLayer {
-        let gradient = CAGradientLayer()
-        gradient.frame = bounds
-        gradient.colors = colors
-        gradient.locations = ratio
-        gradient.startPoint = CGPoint(x: 0.5, y: 1)
-        gradient.endPoint = CGPoint(x: 0.5, y: 0)
-        return gradient
-    }
-
-    private func gradientColor(gradientLayer: CAGradientLayer) -> UIColor {
-        UIGraphicsBeginImageContextWithOptions(gradientLayer.bounds.size, false, 0.0)
-        guard let currentContext = UIGraphicsGetCurrentContext()
-        else { return .boosterLabel }
-        gradientLayer.render(in: currentContext)
-        guard let image = UIGraphicsGetImageFromCurrentImageContext()
-        else { return .boosterLabel }
-        UIGraphicsEndImageContext()
-
-        return UIColor(patternImage: image)
     }
 }

--- a/Booster/Booster/ViewControllers/Home/HomeViewController.swift
+++ b/Booster/Booster/ViewControllers/Home/HomeViewController.swift
@@ -51,24 +51,20 @@ final class HomeViewController: UIViewController {
             .subscribe({ [weak self] homeModel in
                 guard let homeModel = homeModel.element
                 else { return }
+                
                 self?.updateUI(using: homeModel)
             })
             .disposed(by: disposeBag)
     }
 
     private func updateUI(using homeModel: HomeModel) {
+        guard let stepRatios = homeModel.stepRatios()
+        else { return }
+        
         kmLabel.text = String(format: "%.2f", homeModel.km)
         kcalLabel.text = "\(homeModel.kcal)"
         timeActiveLabel.text = homeModel.activeTime.stringToMinutesAndSeconds()
-        configureHourlyChartView()
-        todayTotalStepCountLabel.drawLabel(step: homeModel.totalStepCount,
-                                           ratio: homeModel.gradientRatio())
-    }
-
-    private func configureHourlyChartView() {
-        guard let stepRatios = viewModel.homeModel.value.hourlyStatistics.stepRatios()
-        else { return }
-
         hourlyBarChartView.drawChart(stepRatios: stepRatios.map { CGFloat($0) }, strings: ["0", "6", "12", "18"])
+        todayTotalStepCountLabel.drawLabel(step: homeModel.totalStepCount, ratio: homeModel.gradientRatio())
     }
 }

--- a/Booster/Booster/ViewModels/Home/HomeViewModel.swift
+++ b/Booster/Booster/ViewModels/Home/HomeViewModel.swift
@@ -27,15 +27,15 @@ final class HomeViewModel {
 
     private func fetchTodayHourlyStepCountsData() {
         homeUsecase.fetchHourlyStepCountsData()
-            .subscribe { [weak self] hkStatisticsEvent in
+            .subscribe { [weak self] stepStatisticsCollection in
                 guard let self = self,
-                      let hkStatistics = hkStatisticsEvent.element,
-                      let entity = self.configureStepStatistics(using: hkStatistics)
+                      let stepStatisticsCollection = stepStatisticsCollection.element
                 else { return }
 
                 var newHomeModel = self.homeModel.value
-                newHomeModel.hourlyStatistics.append(entity)
+                newHomeModel.hourlyStatistics = stepStatisticsCollection
                 self.homeModel.accept(newHomeModel)
+
             }
             .disposed(by: disposeBag)
     }
@@ -47,12 +47,13 @@ final class HomeViewModel {
                       let statistics = result.element
                 else { return }
 
-                let distance = statistics.sumQuantity()?.doubleValue(for: HKUnit.meter()) ?? 0
+                let distance = statistics?.sumQuantity()?.doubleValue(for: HKUnit.meter()) ?? 0
                 let km = distance / 1000
 
                 var newHomeModel = self.homeModel.value
                 newHomeModel.km = km
                 self.homeModel.accept(newHomeModel)
+
             }
             .disposed(by: disposeBag)
     }
@@ -64,7 +65,7 @@ final class HomeViewModel {
                       let statistics = result.element
                 else { return }
 
-                let kcal = statistics.sumQuantity()?.doubleValue(for: HKUnit.kilocalorie()) ?? 0
+                let kcal = statistics?.sumQuantity()?.doubleValue(for: HKUnit.kilocalorie()) ?? 0
 
                 var newHomeModel = self.homeModel.value
                 newHomeModel.kcal = Int(kcal)
@@ -78,29 +79,19 @@ final class HomeViewModel {
         homeUsecase.fetchTodayTotalData(type: .stepCount)
             .subscribe { [weak self] result in
                 guard let self = self,
-                      let statistics = result.element,
-                      let seconds = statistics.duration()?.doubleValue(for: .second()),
-                      let sum = statistics.sumQuantity()?.doubleValue(for: .count())
+                      let statistics = result.element
                 else { return }
 
+                let time = statistics?.duration()?.doubleValue(for: .second()) ?? 0
+                let sum = statistics?.sumQuantity()?.doubleValue(for: .count()) ?? 0
+
                 var newHomeModel = self.homeModel.value
-                newHomeModel.activeTime = TimeInterval(seconds)
+                newHomeModel.activeTime = TimeInterval(time)
                 newHomeModel.totalStepCount = Int(sum)
+
                 self.homeModel.accept(newHomeModel)
 
             }
             .disposed(by: disposeBag)
-    }
-
-    private func configureStepStatistics(using statistics: HKStatistics) -> StepStatistics? {
-        let dateFormatter = DateFormatter()
-        dateFormatter.locale = Locale(identifier: "ko_KR")
-        dateFormatter.dateFormat = "H"
-
-        let step = Int(statistics.sumQuantity()?.doubleValue(for: HKUnit.count()) ?? 0)
-        let date = statistics.startDate
-        let string = dateFormatter.string(from: date)
-
-        return StepStatistics(step: step, abbreviatedDateString: string)
     }
 }

--- a/Booster/Booster/Views/Home/GradientLabel.swift
+++ b/Booster/Booster/Views/Home/GradientLabel.swift
@@ -1,0 +1,61 @@
+//
+//  GradientLabel.swift
+//  Booster
+//
+//  Created by Hani on 2021/11/25.
+//
+
+import UIKit
+
+final class GradientLabel: UILabel {
+    private enum Opacity {
+        static let zero: Float = 0
+        static let one: Float = 1
+    }
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+    }
+
+    func drawLabel(step: Int, ratio: Double) {
+        text = "\(step)"
+
+        layer.opacity = Opacity.zero
+
+        let gradientLayer: CAGradientLayer = configuregradientLayer(using: ratio)
+        let gradientColor: UIColor = configureGradientColor(using: gradientLayer)
+        textColor = gradientColor
+        
+        UIView.animate(withDuration: 2) { [weak self] in
+            self?.layer.opacity = Opacity.one
+        }
+    }
+
+    private func configuregradientLayer(using ratio: Double) -> CAGradientLayer {
+        let ratio = NSNumber(value: ratio * 0.75 + 0.25)
+
+        let gradient = CAGradientLayer()
+        gradient.frame = self.bounds
+        gradient.colors =  [UIColor.boosterOrange.cgColor, UIColor.boosterLabel.cgColor]
+        gradient.locations = [ratio, ratio]
+        gradient.startPoint = CGPoint(x: 0.5, y: 1)
+        gradient.endPoint = CGPoint(x: 0.5, y: 0)
+
+        return gradient
+    }
+
+    private func configureGradientColor(using gradientLayer: CAGradientLayer) -> UIColor {
+        UIGraphicsBeginImageContextWithOptions(gradientLayer.bounds.size, false, 0.0)
+        guard let currentContext = UIGraphicsGetCurrentContext()
+        else { return .boosterLabel }
+        gradientLayer.render(in: currentContext)
+        guard let image = UIGraphicsGetImageFromCurrentImageContext()
+        else { return .boosterLabel }
+        UIGraphicsEndImageContext()
+        return UIColor(patternImage: image)
+    }
+}


### PR DESCRIPTION
### 작업 내용
그래디언트 라벨 생성
뷰모델 일부 로직 유즈케이스 이동


### 하고싶은 말
뷰가 해야할 일을 뷰컨이 대신 하고 있었는데
커스텀 라벨이 뷰를 그려주는 역할을 다시 가져가서
뷰컨의 부담이 줄어들었습니당

requestStatisticsQuery가 nil을 반환하면 onNext하지 않아서 (ex. 오늘 걸음수가 하나도 없을때 )
usecase, viewmodel이 아무 반응을 안하여 nil이라도 반환하도록 수정