### PR TITLE
[B, 마일스톤] 리팩토링

### DIFF
--- a/Booster/Booster/Models/Coordinate.swift
+++ b/Booster/Booster/Models/Coordinate.swift
@@ -23,8 +23,16 @@ final class Coordinates {
         return coordinates[index]
     }
 
-    init(coordinates: [Coordinate] = []) {
+    init() {
+        self.coordinates = []
+    }
+
+    init(coordinates: [Coordinate]) {
         self.coordinates = coordinates
+    }
+
+    init(coordinate: Coordinate) {
+        self.coordinates = [coordinate]
     }
 
     func append(_ coordinate: Coordinate) {
@@ -33,6 +41,10 @@ final class Coordinates {
 
     func append(_ newCoordinates: [Coordinate]) {
         coordinates += newCoordinates
+    }
+
+    func append(_ newCoordinates: Coordinates) {
+        coordinates += newCoordinates.coordinates
     }
 
     func center() -> Coordinate {

--- a/Booster/Booster/Models/Milestone.swift
+++ b/Booster/Booster/Models/Milestone.swift
@@ -23,7 +23,15 @@ final class Milestones {
         return milestones[index]
     }
 
-    init(milestones: [Milestone] = []) {
+    init() {
+        self.milestones = []
+    }
+
+    init(milestone: Milestone) {
+        self.milestones = [milestone]
+    }
+
+    init(milestones: [Milestone]) {
         self.milestones = milestones
     }
 
@@ -33,6 +41,13 @@ final class Milestones {
 
     func append(_ newMilestone: [Milestone]) {
         milestones += newMilestone
+    }
+
+    func remove(of milestone: Milestone) -> Milestone? {
+        guard let index = firstIndex(of: milestone)
+        else { return nil }
+
+        return milestones.remove(at: index)
     }
 
     func firstIndex(of milestone: Milestone) -> Int? {

--- a/Booster/Booster/Models/Milestone.swift
+++ b/Booster/Booster/Models/Milestone.swift
@@ -1,5 +1,51 @@
 import Foundation
 
+final class Milestones {
+    private var milestones: [Milestone]
+
+    var first: Milestone? {
+        return milestones.first
+    }
+    var last: Milestone? {
+        return milestones.last
+    }
+    var count: Int {
+        return milestones.count
+    }
+    var all: [Milestone] {
+        return milestones
+    }
+
+    subscript(index: Int) -> Milestone? {
+        if index > milestones.count - 1 {
+            return nil
+        }
+        return milestones[index]
+    }
+
+    init(milestones: [Milestone] = []) {
+        self.milestones = milestones
+    }
+
+    func append(_ milestone: Milestone) {
+        milestones.append(milestone)
+    }
+
+    func append(_ newMilestone: [Milestone]) {
+        milestones += newMilestone
+    }
+
+    func firstIndex(of milestone: Milestone) -> Int? {
+        return milestones.firstIndex(of: milestone)
+    }
+
+    func milestone(at coordinate: Coordinate) -> Milestone? {
+        return milestones.first(where: { milestone in
+            milestone.coordinate == coordinate
+        })
+    }
+}
+
 final class Milestone: NSObject, NSCoding {
     var coordinate: Coordinate
     var imageData: Data

--- a/Booster/Booster/Models/TrackingModel.swift
+++ b/Booster/Booster/Models/TrackingModel.swift
@@ -8,7 +8,7 @@ struct TrackingModel {
     var seconds: Int
     var distance: Double
     var coordinates: Coordinates
-    var milestones: [Milestone]
+    var milestones: Milestones
     var title: String
     var content: String
     var imageData: Data
@@ -21,7 +21,7 @@ struct TrackingModel {
          seconds: Int = 0,
          distance: Double = 0,
          coordinates: Coordinates = Coordinates(),
-         milestones: [Milestone] = [],
+         milestones: Milestones = Milestones(),
          title: String = "",
          content: String = "",
          imageData: Data = Data(),

--- a/Booster/Booster/Usecases/DetailFeedUsecase.swift
+++ b/Booster/Booster/Usecases/DetailFeedUsecase.swift
@@ -87,7 +87,7 @@ final class DetailFeedUsecase: DetailFeedUsecaseProtocol {
                                               seconds: Int(tracking.seconds),
                                               distance: tracking.distance,
                                               coordinates: Coordinates(coordinates: coordinates),
-                                              milestones: milestones,
+                                              milestones: Milestones(milestones: milestones),
                                               title: title,
                                               content: content,
                                               imageData: imageData)

--- a/Booster/Booster/Usecases/TrackingProgressUsecase.swift
+++ b/Booster/Booster/Usecases/TrackingProgressUsecase.swift
@@ -34,7 +34,7 @@ final class TrackingProgressUsecase {
     func save(model: TrackingModel) -> Observable<Void> {
         let entity = "Tracking"
         guard let coordinates = try? NSKeyedArchiver.archivedData(withRootObject: model.coordinates.all, requiringSecureCoding: false),
-              let milestones = try? NSKeyedArchiver.archivedData(withRootObject: model.milestones, requiringSecureCoding: false),
+              let milestones = try? NSKeyedArchiver.archivedData(withRootObject: model.milestones.all, requiringSecureCoding: false),
               let endDate = model.endDate,
               let distance = Double(String(format: "%.2f", model.distance/1000))
         else {

--- a/Booster/Booster/ViewModels/Feed/DetailFeedViewModel.swift
+++ b/Booster/Booster/ViewModels/Feed/DetailFeedViewModel.swift
@@ -30,9 +30,7 @@ final class DetailFeedViewModel {
 
     // MARK: - Functions
     func milestone(at coordinate: Coordinate) -> Milestone? {
-        let target = trackingModel.value.milestones.first(where: { value in
-            return value.coordinate == coordinate
-        })
+        let target = trackingModel.value.milestones.milestone(at: coordinate)
 
         return target
     }
@@ -40,13 +38,10 @@ final class DetailFeedViewModel {
     func reset() { gradientColorOffset = -1 }
 
     func remove(of milestone: Milestone) {
-        guard let index = trackingModel.value.milestones.firstIndex(of: milestone)
-        else { return }
+        let newTrackingModel = self.trackingModel.value
+        _ = newTrackingModel.milestones.remove(of: milestone)
 
-        var newTrackingModel = self.trackingModel.value
-        _ = newTrackingModel.milestones.remove(at: index)
-
-        usecase.update(milestones: newTrackingModel.milestones, predicate: predicate)
+        usecase.update(milestones: newTrackingModel.milestones.all, predicate: predicate)
             .subscribe(onError: { _ in
                 self.isDeletedMilestone.onNext(false)
             }, onCompleted: {

--- a/Booster/Booster/ViewModels/Tracking/TrackingProgressViewModel.swift
+++ b/Booster/Booster/ViewModels/Tracking/TrackingProgressViewModel.swift
@@ -17,12 +17,15 @@ final class TrackingProgressViewModel {
     let steps = PublishSubject<Int>()
     let distance = PublishSubject<Double>()
     let saveResult = PublishSubject<Error?>()
-    let coordinates = PublishSubject<[Coordinate]>()
+    let coordinates = PublishSubject<Coordinates>()
     let addMilestones = PublishSubject<[Milestone]>()
+    var lastCoordinate: Coordinate? {
+        return trackingModel.value.coordinates.last
+    }
     private let disposeBag = DisposeBag()
     private let trackingUsecase: TrackingProgressUsecase
-    private(set) var tracking = BehaviorRelay<TrackingModel>(value: TrackingModel())
-    private(set) var user =  BehaviorRelay<UserInfo>(value: UserInfo())
+    private(set) var trackingModel = BehaviorRelay<TrackingModel>(value: TrackingModel())
+    private(set) var userModel =  BehaviorRelay<UserInfo>(value: UserInfo())
     private(set) var state = BehaviorRelay<TrackingState>(value: .start)
 
     init() {
@@ -31,32 +34,18 @@ final class TrackingProgressViewModel {
         bind()
     }
 
-    func latestCoordinate() -> Coordinate? {
-        guard let latestCoordinate: Coordinate = tracking.value.coordinates.last
-        else { return nil }
-
-        return latestCoordinate
-    }
-
-    func startCoordinate() -> Coordinate? {
-        guard let startCoordinate: Coordinate = tracking.value.coordinates.first
-        else { return nil }
-
-        return startCoordinate
-    }
-
     func save() {
-        return trackingUsecase.save(model: self.tracking.value)
-            .subscribe(onNext: {
-                self.saveResult.onNext(nil)
-            }, onError: { error in
-                self.saveResult.onNext(error)
+        return trackingUsecase.save(model: trackingModel.value)
+            .subscribe(onNext: { [weak self] in
+                self?.saveResult.onNext(nil)
+            }, onError: { [weak self] error in
+                self?.saveResult.onNext(error)
             }).disposed(by: disposeBag)
     }
 
     func mileStone(at coordinate: Coordinate) -> Observable<Milestone?> {
-        return Observable.create { observable in
-            let target = self.tracking.value.milestones.first(where: { (value) in
+        return Observable.create { [weak self] observable in
+            let target = self?.trackingModel.value.milestones.first(where: { (value) in
                 return value.coordinate == coordinate
             })
 
@@ -67,12 +56,15 @@ final class TrackingProgressViewModel {
     }
 
     func remove(of mileStone: Milestone) -> Observable<Bool> {
-        return Observable.create { observable in
-            var tracking = self.tracking.value
+        return Observable.create { [weak self] observable in
+            guard let self = self
+            else { return Disposables.create() }
 
-            if let index = self.tracking.value.milestones.firstIndex(of: mileStone) {
+            var tracking = self.trackingModel.value
+
+            if let index = self.trackingModel.value.milestones.firstIndex(of: mileStone) {
                 tracking.milestones.remove(at: index)
-                self.tracking.accept(tracking)
+                self.trackingModel.accept(tracking)
 
                 observable.onNext(true)
             } else {
@@ -84,7 +76,7 @@ final class TrackingProgressViewModel {
     }
 
     func centerCoordinateOfPath() -> CLLocationCoordinate2D? {
-        let center = tracking.value.coordinates.center()
+        let center = trackingModel.value.coordinates.center()
         guard let latitude = center.latitude,
               let longitude = center.longitude
         else { return nil }
@@ -93,29 +85,29 @@ final class TrackingProgressViewModel {
 
     private func bind() {
         coordinates.map { (values) -> [Coordinate] in
-            let coordinates = self.tracking.value.coordinates
+            let coordinates = self.trackingModel.value.coordinates
             coordinates.append(values)
             return coordinates.all
         }.bind { [weak self] values in
             guard let self = self
             else { return }
 
-            var tracking = self.tracking.value
+            var tracking = self.trackingModel.value
             tracking.coordinates = Coordinates(coordinates: values)
-            self.tracking.accept(tracking)
+            self.trackingModel.accept(tracking)
         }.disposed(by: disposeBag)
 
         addMilestones.map { (values) -> [Milestone] in
-            var milestones = self.tracking.value.milestones
+            var milestones = self.trackingModel.value.milestones
             milestones += values
             return milestones
         }.bind { [weak self] values in
             guard let self = self
             else { return }
 
-            var tracking = self.tracking.value
+            var tracking = self.trackingModel.value
             tracking.milestones = values
-            self.tracking.accept(tracking)
+            self.trackingModel.accept(tracking)
         }.disposed(by: disposeBag)
 
         state.filter {
@@ -124,9 +116,9 @@ final class TrackingProgressViewModel {
             guard let self = self
             else { return TrackingModel() }
 
-            var tracking = self.tracking.value
+            var tracking = self.trackingModel.value
             tracking.endDate = Date()
-            self.tracking.accept(tracking)
+            self.trackingModel.accept(tracking)
             return tracking
         }.bind { [weak self] tracking in
             self?.trackingUsecase.save(count: Double(tracking.steps),
@@ -152,73 +144,73 @@ final class TrackingProgressViewModel {
             guard let self = self
             else { return }
 
-            var tracking = self.tracking.value
+            var tracking = self.trackingModel.value
             tracking.coordinates.append(Coordinate(latitude: nil, longitude: nil))
-            self.tracking.accept(tracking)
+            self.trackingModel.accept(tracking)
         }.disposed(by: disposeBag)
 
         title.bind { [weak self] value in
             guard let self = self
             else { return }
 
-            var tracking = self.tracking.value
+            var tracking = self.trackingModel.value
             tracking.title = value
-            self.tracking.accept(tracking)
+            self.trackingModel.accept(tracking)
         }.disposed(by: disposeBag)
 
         content.bind { [weak self] value in
             guard let self = self
             else { return }
 
-            var tracking = self.tracking.value
+            var tracking = self.trackingModel.value
             tracking.content = value
-            self.tracking.accept(tracking)
+            self.trackingModel.accept(tracking)
         }.disposed(by: disposeBag)
 
         imageData.bind { value in
-            var tracking = self.tracking.value
+            var tracking = self.trackingModel.value
             tracking.imageData = value
-            self.tracking.accept(tracking)
+            self.trackingModel.accept(tracking)
         }.disposed(by: disposeBag)
 
         seconds.bind { [weak self] value in
             guard let self = self
             else { return }
 
-            var tracking = self.tracking.value
+            var tracking = self.trackingModel.value
             tracking.seconds = value
-            self.tracking.accept(tracking)
+            self.trackingModel.accept(tracking)
         }.disposed(by: disposeBag)
 
         steps.bind { [weak self] value in
             guard let self = self
             else { return }
 
-            var tracking = self.tracking.value
+            var tracking = self.trackingModel.value
 
             tracking.steps += value
-            self.tracking.accept(tracking)
+            self.trackingModel.accept(tracking)
         }.disposed(by: disposeBag)
 
         distance.bind { [weak self] value in
             guard let self = self
             else { return }
 
-            var tracking = self.tracking.value
+            var tracking = self.trackingModel.value
             let met: Double = 4.8
             let perHourDistance = 5.6 * 1000
 
             tracking.distance += value
-            tracking.calories = Int(met * Double(self.user.value.weight) * (tracking.distance / perHourDistance))
+            tracking.calories = Int(met * Double(self.userModel.value.weight) * (tracking.distance / perHourDistance))
 
-            self.tracking.accept(tracking)
+            self.trackingModel.accept(tracking)
         }.disposed(by: disposeBag)
     }
 
     private func fetchUserInfo() {
         trackingUsecase.fetch()
             .subscribe { [weak self] value in
-                self?.user.accept(value)
+                self?.userModel.accept(value)
             }.disposed(by: disposeBag)
     }
 }

--- a/Booster/Booster/Views/Feed/DetailFeedMapView.swift
+++ b/Booster/Booster/Views/Feed/DetailFeedMapView.swift
@@ -28,7 +28,7 @@ final class DetailFeedMapView: BoosterMapView {
         let centerLocation = value.coordinates.center()
         setRegion(to: CLLocation(latitude: centerLocation.latitude ?? 0, longitude: centerLocation.longitude ?? 0), meterRadius: value.distance * 1000 + 50)
 
-        configureMilestones(value.milestones)
+        configureMilestones(value.milestones.all)
     }
 
     func createMilestoneView(milestone: Milestone, color: UIColor) -> MKAnnotationView? {


### PR DESCRIPTION
### 필독 권장 (희주님, 태훈님)
> `TrackingModel`의 `milestones: [Milestone]` -> `milestones: Milestones` 로의 변경이 이루어 졌습니다.
- 희주님
희주님의 코드 일부분이 살짝 변경되었습니다! 희주님 쪽의 로직 변화는 없고 접근 방식만 달라진 상태입니다

- 태훈님
`TrackingProgressViewController`, `TrackingProgressViewModel` 쪽의 로직 중 Milestone과 관련된 로직이 일부 변경되었습니다.
크게 변수명, 변수타입과 Observable이 필요없다고 괜찮다고 생각되는 부분을 변경시켰습니다.
이 변경사항은 제 독단으로 임의로 변경한 것이기에 태훈님과 이야기를 나눠보고 충분히 변경할 의향이 있습니다! PR 보시거나 오늘 이야기를 나눠보는것이 좋을 것 같아요!

### 작업 내용
- TrackingProgressViewModel의 tracking, user 명칭을  trackingModel, userModel로 변경
- addMilestone(구 PublishSubject) 명칭을 cachedMilestone(신 BehaviorRelay) 으로 변경
- TrackingProgressViewModel이 과도하게 로직을 처리하고 있어 일부 로직을 이동
    - milestones: [Milestone] -> milestones: Milestones 로의 변경.
- TrackingProgressViewModel의 append 리턴 타입 Observable 제거
- 마일스톤 중복 제거 로직 변경

### 체크리스트
- [x] Milestones 클래스 생성
- [x] Milestone과 관련된 코드 리팩토링 

### 구현 설명
- TrackingProgressViewModel이 과도하게 로직을 처리하고 있어 일부 로직을 이동
        > Milestones 클래스 생성으로 인하여 위의 로직을 해당 클래스로 이동하였습니다. Coordinates와 유사한 구조입니다.
- TrackingProgressViewModel의 milestone(at: Coordinate)가 Milestones 클래스로의 이동으로 인한 Observable 로직 변경

현재 로직의 흐름이 다음과 같습니다.
> 1. append -> cachedMilestone에 추가
> 2. bind 되어있는 cachedMilestones가 trackingModel에 값을 업데이트
> 3. VC에 bind 되어있는 cachedMilestones가 mapView의 addAnnotation을 수행
- 마일스톤 중복 제거 로직 변경
`<TrackingProgressViewController>` `bindView()`의 `leftButton.rx.tap`의 중복 제거 검사 로직을 단순 비교로 변경
### 하고싶은 말
