### PR TITLE
[A, D] DetailFeed 리팩토링 및 뷰 재사용 추가

### DIFF
--- a/Booster/Booster.xcodeproj/project.pbxproj
+++ b/Booster/Booster.xcodeproj/project.pbxproj
@@ -19,6 +19,8 @@
 		28C9703D274C87D1005BD7BC /* WritingRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28C9703C274C87D1005BD7BC /* WritingRecord.swift */; };
 		28C97066274E21CC005BD7BC /* BoosterMapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28C97065274E21CC005BD7BC /* BoosterMapView.swift */; };
 		28C97068274E26E1005BD7BC /* DetailFeedMapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28C97067274E26E1005BD7BC /* DetailFeedMapView.swift */; };
+		28C9708A275283FA005BD7BC /* UIView+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28C97089275283FA005BD7BC /* UIView+Extension.swift */; };
+		28C9708C27528CFC005BD7BC /* ThreeColumnRecordView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28C9708B27528CFC005BD7BC /* ThreeColumnRecordView.swift */; };
 		37852ACF273C27F100BA3D67 /* StatisticsModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37852ACE273C27F100BA3D67 /* StatisticsModelTests.swift */; };
 		37852AD8273C2D0B00BA3D67 /* StepStatisticsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37852AD7273C2D0B00BA3D67 /* StepStatisticsTests.swift */; };
 		379E3C57273BC182002B0B15 /* ChartView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 379E3C56273BC182002B0B15 /* ChartView.swift */; };
@@ -161,6 +163,8 @@
 		28C9703C274C87D1005BD7BC /* WritingRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WritingRecord.swift; sourceTree = "<group>"; };
 		28C97065274E21CC005BD7BC /* BoosterMapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoosterMapView.swift; sourceTree = "<group>"; };
 		28C97067274E26E1005BD7BC /* DetailFeedMapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailFeedMapView.swift; sourceTree = "<group>"; };
+		28C97089275283FA005BD7BC /* UIView+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Extension.swift"; sourceTree = "<group>"; };
+		28C9708B27528CFC005BD7BC /* ThreeColumnRecordView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreeColumnRecordView.swift; sourceTree = "<group>"; };
 		37852ACC273C27F100BA3D67 /* StatisticsTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = StatisticsTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		37852ACE273C27F100BA3D67 /* StatisticsModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatisticsModelTests.swift; sourceTree = "<group>"; };
 		37852AD7273C2D0B00BA3D67 /* StepStatisticsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StepStatisticsTests.swift; sourceTree = "<group>"; };
@@ -364,6 +368,7 @@
 				3B6FE5022743A85B00A815D1 /* InfoPickerView.swift */,
 				28C97065274E21CC005BD7BC /* BoosterMapView.swift */,
 				FA614F8D2733CF9000B090D9 /* EmptyView.swift */,
+				28C9708B27528CFC005BD7BC /* ThreeColumnRecordView.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -679,6 +684,7 @@
 				FA473A04273A1F8A0000C5DC /* UIImage+Extension.swift */,
 				28C96FF2273A4634005BD7BC /* UIResponder+Extension.swift */,
 				FACBAB692746034900CD6B76 /* UIButton+Extension.swift */,
+				28C97089275283FA005BD7BC /* UIView+Extension.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -1011,6 +1017,7 @@
 				FA473A4527438A3E0000C5DC /* MyInfoHeaderView.swift in Sources */,
 				3B37B99C274371B9001EB120 /* GenderEnrollView.swift in Sources */,
 				FA614F792733CDAA00B090D9 /* UIAlertController+Extention.swift in Sources */,
+				28C9708A275283FA005BD7BC /* UIView+Extension.swift in Sources */,
 				FA614F832733CDAA00B090D9 /* FeedViewController.swift in Sources */,
 				FA614F712733CDAA00B090D9 /* Milestone.swift in Sources */,
 				FA2578F72745E99800597382 /* EditUserInfoViewController.swift in Sources */,
@@ -1042,6 +1049,7 @@
 				FA614F942733D51C00B090D9 /* EnrollViewController.swift in Sources */,
 				FA614F7B2733CDAA00B090D9 /* BoosterObservable.swift in Sources */,
 				FA614F7F2733CDAA00B090D9 /* HomeViewController.swift in Sources */,
+				28C9708C27528CFC005BD7BC /* ThreeColumnRecordView.swift in Sources */,
 				28C9702D273C3041005BD7BC /* DetailFeedUsecase.swift in Sources */,
 				FA614F8A2733CDAA00B090D9 /* TrackingProgressUsecase.swift in Sources */,
 				FAAD240B274D0F23009E2F52 /* NotificationSettingViewModel.swift in Sources */,

--- a/Booster/Booster/Extensions/UIView+Extension.swift
+++ b/Booster/Booster/Extensions/UIView+Extension.swift
@@ -12,9 +12,9 @@ extension UIView {
         let currentFrame: CGRect = self.frame
 
         self.frame = CGRect.init(x: 0,
-                                           y: 0,
-                                           width: self.frame.size.width,
-                                           height: self.frame.size.height)
+                                 y: 0,
+                                 width: self.frame.size.width,
+                                 height: self.frame.size.height)
 
         UIGraphicsBeginImageContextWithOptions(self.frame.size,
                                                true,

--- a/Booster/Booster/Extensions/UIView+Extension.swift
+++ b/Booster/Booster/Extensions/UIView+Extension.swift
@@ -1,0 +1,33 @@
+//
+//  UIView+Extension.swift
+//  Booster
+//
+//  Created by hiju on 2021/11/28.
+//
+
+import UIKit
+
+extension UIView {
+    func snapshot() -> UIImage? {
+        let currentFrame: CGRect = self.frame
+
+        self.frame = CGRect.init(x: 0,
+                                           y: 0,
+                                           width: self.frame.size.width,
+                                           height: self.frame.size.height)
+
+        UIGraphicsBeginImageContextWithOptions(self.frame.size,
+                                               true,
+                                               0.0)
+        guard let cgContext = UIGraphicsGetCurrentContext()
+        else { return nil }
+        self.layer.render(in: cgContext)
+        guard let image = UIGraphicsGetImageFromCurrentImageContext()
+        else { return nil }
+        self.frame = currentFrame
+
+        UIGraphicsEndImageContext()
+
+        return image
+    }
+}

--- a/Booster/Booster/Models/Coordinate.swift
+++ b/Booster/Booster/Models/Coordinate.swift
@@ -50,6 +50,12 @@ final class Coordinates {
         return Coordinate(latitude: centerLatitude, longitude: centerLongitude)
     }
 
+    func indexRatio(_ coordinate: Coordinate) -> Double? {
+        guard let index = coordinates.firstIndex(of: coordinate)
+        else { return nil }
+        return Double(index) / Double(coordinates.count)
+    }
+
     func firstIndex(of coordinate: Coordinate) -> Int? {
         return coordinates.firstIndex(of: coordinate)
     }

--- a/Booster/Booster/Storyboards/Feed.storyboard
+++ b/Booster/Booster/Storyboards/Feed.storyboard
@@ -154,37 +154,37 @@
                                                 <rect key="frame" x="0.0" y="0.0" width="414" height="664"/>
                                                 <subviews>
                                                     <mapView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" mapType="standard" translatesAutoresizingMaskIntoConstraints="NO" id="gCe-Qv-haU" customClass="DetailFeedMapView" customModule="Booster" customModuleProvider="target">
-                                                        <rect key="frame" x="30" y="89" width="354" height="354"/>
+                                                        <rect key="frame" x="30" y="101" width="354" height="354"/>
                                                         <constraints>
                                                             <constraint firstAttribute="width" secondItem="gCe-Qv-haU" secondAttribute="height" multiplier="1:1" id="cJO-Xl-ovD"/>
                                                         </constraints>
                                                     </mapView>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="산책 제목" textAlignment="natural" lineBreakMode="characterWrap" numberOfLines="2" baselineAdjustment="alignBaselines" minimumFontSize="20" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="IQ7-gI-wGX">
-                                                        <rect key="frame" x="30" y="20" width="354" height="35"/>
+                                                        <rect key="frame" x="30" y="20" width="354" height="43.5"/>
                                                         <fontDescription key="fontDescription" name="NotoSansKR-Medium" family="Noto Sans KR" pointSize="30"/>
                                                         <color key="textColor" name="boosterLabel"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="gangnam-gu" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fmg-7e-yqO">
-                                                        <rect key="frame" x="30" y="55" width="354" height="14"/>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="booster-gu, booster-si" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fmg-7e-yqO">
+                                                        <rect key="frame" x="30" y="63.5" width="354" height="17.5"/>
                                                         <fontDescription key="fontDescription" name="NotoSansKR-Light" family="Noto Sans KR" pointSize="12"/>
                                                         <color key="textColor" name="boosterLabel"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="B7Q-Cx-YM2">
-                                                        <rect key="frame" x="30" y="463" width="28" height="58.5"/>
+                                                        <rect key="frame" x="30" y="475" width="33.5" height="59.5"/>
                                                         <fontDescription key="fontDescription" name="Bazaronite" family="Bazaronite" pointSize="50"/>
                                                         <color key="textColor" name="boosterOrange"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="steps" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ph3-zt-nOG">
-                                                        <rect key="frame" x="63" y="488" width="49" height="23.5"/>
+                                                        <rect key="frame" x="68.5" y="495.5" width="49" height="29"/>
                                                         <fontDescription key="fontDescription" name="NotoSansKR-Regular" family="Noto Sans KR" pointSize="20"/>
                                                         <color key="textColor" name="boosterOrange"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="RSR-tU-lf1" customClass="ThreeColumnRecordView" customModule="Booster" customModuleProvider="target">
-                                                        <rect key="frame" x="0.0" y="551.5" width="414" height="112.5"/>
+                                                        <rect key="frame" x="0.0" y="564.5" width="414" height="99.5"/>
                                                         <color key="backgroundColor" name="boosterBackground"/>
                                                     </view>
                                                 </subviews>
@@ -211,7 +211,7 @@
                                                 </constraints>
                                             </view>
                                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" userInteractionEnabled="NO" contentMode="scaleToFill" scrollEnabled="NO" text="--" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="BvC-uD-hJr">
-                                                <rect key="frame" x="30" y="664" width="354" height="40"/>
+                                                <rect key="frame" x="30" y="664" width="354" height="45"/>
                                                 <color key="backgroundColor" name="boosterBackground"/>
                                                 <color key="tintColor" name="boosterOrange"/>
                                                 <color key="textColor" name="boosterLabel"/>
@@ -283,7 +283,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" text="아직 안했지롱" textAlignment="justified" translatesAutoresizingMaskIntoConstraints="NO" id="0sF-uL-ly2">
-                                <rect key="frame" x="30" y="127.5" width="354" height="269"/>
+                                <rect key="frame" x="30" y="136" width="354" height="269"/>
                                 <color key="backgroundColor" name="boosterBackground"/>
                                 <color key="tintColor" name="boosterOrange"/>
                                 <color key="textColor" name="boosterLabel"/>
@@ -291,7 +291,7 @@
                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                             </textView>
                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="라랄라" placeholder="제목" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="eKE-zl-J4v">
-                                <rect key="frame" x="30" y="74" width="354" height="36.5"/>
+                                <rect key="frame" x="30" y="74" width="354" height="45"/>
                                 <color key="tintColor" name="boosterOrange"/>
                                 <color key="textColor" name="boosterLabel"/>
                                 <fontDescription key="fontDescription" name="NotoSansKR-Medium" family="Noto Sans KR" pointSize="30"/>

--- a/Booster/Booster/Storyboards/Feed.storyboard
+++ b/Booster/Booster/Storyboards/Feed.storyboard
@@ -154,104 +154,64 @@
                                                 <rect key="frame" x="0.0" y="0.0" width="414" height="664"/>
                                                 <subviews>
                                                     <mapView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" mapType="standard" translatesAutoresizingMaskIntoConstraints="NO" id="gCe-Qv-haU" customClass="DetailFeedMapView" customModule="Booster" customModuleProvider="target">
-                                                        <rect key="frame" x="30" y="101" width="354" height="354"/>
+                                                        <rect key="frame" x="30" y="89" width="354" height="354"/>
                                                         <constraints>
                                                             <constraint firstAttribute="width" secondItem="gCe-Qv-haU" secondAttribute="height" multiplier="1:1" id="cJO-Xl-ovD"/>
                                                         </constraints>
                                                     </mapView>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="산책 제목" textAlignment="natural" lineBreakMode="characterWrap" numberOfLines="2" baselineAdjustment="alignBaselines" minimumFontSize="20" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="IQ7-gI-wGX">
-                                                        <rect key="frame" x="30" y="20" width="354" height="43.5"/>
+                                                        <rect key="frame" x="30" y="20" width="354" height="35"/>
                                                         <fontDescription key="fontDescription" name="NotoSansKR-Medium" family="Noto Sans KR" pointSize="30"/>
                                                         <color key="textColor" name="boosterLabel"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="gangnam-gu" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fmg-7e-yqO">
-                                                        <rect key="frame" x="30" y="63.5" width="354" height="17.5"/>
+                                                        <rect key="frame" x="30" y="55" width="354" height="14"/>
                                                         <fontDescription key="fontDescription" name="NotoSansKR-Light" family="Noto Sans KR" pointSize="12"/>
                                                         <color key="textColor" name="boosterLabel"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="B7Q-Cx-YM2">
-                                                        <rect key="frame" x="30" y="475" width="33.5" height="59.5"/>
+                                                        <rect key="frame" x="30" y="463" width="28" height="58.5"/>
                                                         <fontDescription key="fontDescription" name="Bazaronite" family="Bazaronite" pointSize="50"/>
                                                         <color key="textColor" name="boosterOrange"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="steps" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ph3-zt-nOG">
-                                                        <rect key="frame" x="68.5" y="495.5" width="49" height="29"/>
+                                                        <rect key="frame" x="63" y="488" width="49" height="23.5"/>
                                                         <fontDescription key="fontDescription" name="NotoSansKR-Regular" family="Noto Sans KR" pointSize="20"/>
                                                         <color key="textColor" name="boosterOrange"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="EpB-cC-q10">
-                                                        <rect key="frame" x="64" y="564.5" width="17" height="30"/>
-                                                        <fontDescription key="fontDescription" name="Bazaronite" family="Bazaronite" pointSize="25"/>
-                                                        <color key="textColor" name="boosterLabel"/>
-                                                        <nil key="highlightedColor"/>
-                                                    </label>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="kcal" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="uRb-Us-F76">
-                                                        <rect key="frame" x="56.5" y="599.5" width="28" height="22"/>
-                                                        <fontDescription key="fontDescription" name="NotoSansKR-Light" family="Noto Sans KR" pointSize="15"/>
-                                                        <color key="textColor" name="boosterLabel"/>
-                                                        <nil key="highlightedColor"/>
-                                                    </label>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="time" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TeL-Ss-n73">
-                                                        <rect key="frame" x="191.5" y="599.5" width="31" height="22"/>
-                                                        <fontDescription key="fontDescription" name="NotoSansKR-Light" family="Noto Sans KR" pointSize="15"/>
-                                                        <color key="textColor" name="boosterLabel"/>
-                                                        <nil key="highlightedColor"/>
-                                                    </label>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HR9-G6-PmX">
-                                                        <rect key="frame" x="200" y="564.5" width="17" height="30"/>
-                                                        <fontDescription key="fontDescription" name="Bazaronite" family="Bazaronite" pointSize="25"/>
-                                                        <color key="textColor" name="boosterLabel"/>
-                                                        <nil key="highlightedColor"/>
-                                                    </label>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="NJw-v9-DGj">
-                                                        <rect key="frame" x="333" y="564.5" width="17" height="30"/>
-                                                        <fontDescription key="fontDescription" name="Bazaronite" family="Bazaronite" pointSize="25"/>
-                                                        <color key="textColor" name="boosterLabel"/>
-                                                        <nil key="highlightedColor"/>
-                                                    </label>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="km" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ekR-0F-WEU">
-                                                        <rect key="frame" x="329.5" y="599.5" width="21" height="22"/>
-                                                        <fontDescription key="fontDescription" name="NotoSansKR-Light" family="Noto Sans KR" pointSize="15"/>
-                                                        <color key="textColor" name="boosterLabel"/>
-                                                        <nil key="highlightedColor"/>
-                                                    </label>
+                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="RSR-tU-lf1" customClass="ThreeColumnRecordView" customModule="Booster" customModuleProvider="target">
+                                                        <rect key="frame" x="0.0" y="551.5" width="414" height="112.5"/>
+                                                        <color key="backgroundColor" name="boosterBackground"/>
+                                                    </view>
                                                 </subviews>
                                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <color key="tintColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <constraints>
-                                                    <constraint firstItem="TeL-Ss-n73" firstAttribute="top" secondItem="HR9-G6-PmX" secondAttribute="bottom" constant="5" id="0Lu-dU-peH"/>
                                                     <constraint firstItem="fmg-7e-yqO" firstAttribute="leading" secondItem="IQ7-gI-wGX" secondAttribute="leading" id="0Mp-bh-XEM"/>
-                                                    <constraint firstItem="uRb-Us-F76" firstAttribute="top" secondItem="EpB-cC-q10" secondAttribute="bottom" constant="5" id="3qz-8T-PJT"/>
                                                     <constraint firstItem="IQ7-gI-wGX" firstAttribute="leading" secondItem="6Lo-0f-1rw" secondAttribute="leading" constant="30" id="4Rp-EB-XNY"/>
-                                                    <constraint firstItem="ekR-0F-WEU" firstAttribute="centerX" secondItem="NJw-v9-DGj" secondAttribute="centerX" multiplier="0.996" id="5SY-W8-kMw"/>
+                                                    <constraint firstItem="RSR-tU-lf1" firstAttribute="top" secondItem="B7Q-Cx-YM2" secondAttribute="bottom" constant="30" id="9PE-fF-kVK"/>
                                                     <constraint firstItem="B7Q-Cx-YM2" firstAttribute="top" secondItem="gCe-Qv-haU" secondAttribute="bottom" constant="20" id="DFd-r0-lhy"/>
-                                                    <constraint firstItem="NJw-v9-DGj" firstAttribute="centerY" secondItem="HR9-G6-PmX" secondAttribute="centerY" id="FVl-eX-YoG"/>
-                                                    <constraint firstItem="ekR-0F-WEU" firstAttribute="top" secondItem="NJw-v9-DGj" secondAttribute="bottom" constant="5" id="Hn2-rg-pLT"/>
+                                                    <constraint firstAttribute="trailing" secondItem="RSR-tU-lf1" secondAttribute="trailing" id="FY3-R1-DRV"/>
                                                     <constraint firstAttribute="trailing" secondItem="IQ7-gI-wGX" secondAttribute="trailing" constant="30" id="M96-cq-Kmh"/>
                                                     <constraint firstItem="B7Q-Cx-YM2" firstAttribute="leading" secondItem="gCe-Qv-haU" secondAttribute="leading" id="MDg-Ep-8Qf"/>
-                                                    <constraint firstItem="TeL-Ss-n73" firstAttribute="centerX" secondItem="6Lo-0f-1rw" secondAttribute="centerX" id="OgO-Pd-ZLn"/>
+                                                    <constraint firstAttribute="bottom" secondItem="RSR-tU-lf1" secondAttribute="bottom" id="Mu0-LE-8un"/>
                                                     <constraint firstItem="fmg-7e-yqO" firstAttribute="top" secondItem="IQ7-gI-wGX" secondAttribute="bottom" id="QH3-e0-AZC"/>
-                                                    <constraint firstItem="NJw-v9-DGj" firstAttribute="centerX" secondItem="6Lo-0f-1rw" secondAttribute="centerX" multiplier="1.65" id="XAp-su-ovR"/>
-                                                    <constraint firstItem="EpB-cC-q10" firstAttribute="centerX" secondItem="6Lo-0f-1rw" secondAttribute="centerX" multiplier="0.35" id="a6s-6B-Xen"/>
-                                                    <constraint firstItem="HR9-G6-PmX" firstAttribute="centerX" secondItem="6Lo-0f-1rw" secondAttribute="centerX" multiplier="1.008" id="etp-4S-3Sh"/>
+                                                    <constraint firstItem="RSR-tU-lf1" firstAttribute="leading" secondItem="6Lo-0f-1rw" secondAttribute="leading" id="c5K-pr-JWm"/>
                                                     <constraint firstItem="ph3-zt-nOG" firstAttribute="leading" secondItem="B7Q-Cx-YM2" secondAttribute="trailing" constant="5" id="igT-J3-I3a"/>
                                                     <constraint firstAttribute="trailing" secondItem="fmg-7e-yqO" secondAttribute="trailing" constant="30" id="lRm-ym-dJo"/>
                                                     <constraint firstItem="ph3-zt-nOG" firstAttribute="bottom" secondItem="B7Q-Cx-YM2" secondAttribute="bottom" constant="-10" id="qNI-Od-BOo"/>
-                                                    <constraint firstItem="HR9-G6-PmX" firstAttribute="top" secondItem="ph3-zt-nOG" secondAttribute="bottom" constant="40" id="s2B-ec-C7s"/>
                                                     <constraint firstAttribute="trailing" secondItem="gCe-Qv-haU" secondAttribute="trailing" constant="30" id="tCj-7I-SZh"/>
                                                     <constraint firstItem="gCe-Qv-haU" firstAttribute="top" secondItem="fmg-7e-yqO" secondAttribute="bottom" constant="20" id="uZN-9b-vK4"/>
-                                                    <constraint firstItem="EpB-cC-q10" firstAttribute="centerY" secondItem="HR9-G6-PmX" secondAttribute="centerY" id="ukH-sT-P7C"/>
                                                     <constraint firstItem="IQ7-gI-wGX" firstAttribute="top" secondItem="6Lo-0f-1rw" secondAttribute="top" constant="20" id="wDm-uw-MWJ"/>
-                                                    <constraint firstItem="uRb-Us-F76" firstAttribute="centerX" secondItem="EpB-cC-q10" secondAttribute="centerX" multiplier="0.97" id="xWt-A2-Ehl"/>
                                                     <constraint firstItem="gCe-Qv-haU" firstAttribute="leading" secondItem="fmg-7e-yqO" secondAttribute="leading" id="yeg-xf-k50"/>
                                                 </constraints>
                                             </view>
                                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" userInteractionEnabled="NO" contentMode="scaleToFill" scrollEnabled="NO" text="--" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="BvC-uD-hJr">
-                                                <rect key="frame" x="30" y="664" width="354" height="45"/>
+                                                <rect key="frame" x="30" y="664" width="354" height="40"/>
                                                 <color key="backgroundColor" name="boosterBackground"/>
                                                 <color key="tintColor" name="boosterOrange"/>
                                                 <color key="textColor" name="boosterLabel"/>
@@ -300,15 +260,13 @@
                     </navigationItem>
                     <connections>
                         <outlet property="contentTextView" destination="BvC-uD-hJr" id="hOH-Qn-ZtH"/>
-                        <outlet property="kcalLabel" destination="EpB-cC-q10" id="Xit-5s-Jm9"/>
-                        <outlet property="kmLabel" destination="NJw-v9-DGj" id="piY-uh-M8H"/>
                         <outlet property="locationInfoLabel" destination="fmg-7e-yqO" id="abW-0v-V0D"/>
                         <outlet property="pathMapView" destination="gCe-Qv-haU" id="vgR-Gc-VPU"/>
+                        <outlet property="recordView" destination="RSR-tU-lf1" id="OsY-dJ-OCp"/>
                         <outlet property="screenshotView" destination="6Lo-0f-1rw" id="iPF-dQ-q6H"/>
                         <outlet property="scrollView" destination="H06-jc-bhO" id="B4e-8d-lik"/>
                         <outlet property="settingBarButtonItem" destination="GPP-8c-MDj" id="hAH-6U-hOT"/>
                         <outlet property="stepCountsLabel" destination="B7Q-Cx-YM2" id="ILD-Ty-DIC"/>
-                        <outlet property="timeLabel" destination="HR9-G6-PmX" id="YSh-Yn-HAk"/>
                         <outlet property="titleLabel" destination="IQ7-gI-wGX" id="PhN-PO-4Os"/>
                     </connections>
                 </viewController>
@@ -325,7 +283,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" text="아직 안했지롱" textAlignment="justified" translatesAutoresizingMaskIntoConstraints="NO" id="0sF-uL-ly2">
-                                <rect key="frame" x="30" y="136" width="354" height="269"/>
+                                <rect key="frame" x="30" y="127.5" width="354" height="269"/>
                                 <color key="backgroundColor" name="boosterBackground"/>
                                 <color key="tintColor" name="boosterOrange"/>
                                 <color key="textColor" name="boosterLabel"/>
@@ -333,7 +291,7 @@
                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                             </textView>
                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="라랄라" placeholder="제목" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="eKE-zl-J4v">
-                                <rect key="frame" x="30" y="74" width="354" height="45"/>
+                                <rect key="frame" x="30" y="74" width="354" height="36.5"/>
                                 <color key="tintColor" name="boosterOrange"/>
                                 <color key="textColor" name="boosterLabel"/>
                                 <fontDescription key="fontDescription" name="NotoSansKR-Medium" family="Noto Sans KR" pointSize="30"/>
@@ -362,7 +320,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="JpP-0M-g5F" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="3022" y="98"/>
+            <point key="canvasLocation" x="3021.739130434783" y="97.767857142857139"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="j4Y-rs-hEH">

--- a/Booster/Booster/Storyboards/Home.storyboard
+++ b/Booster/Booster/Storyboards/Home.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Y6W-OH-hqX">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Y6W-OH-hqX">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -28,45 +28,9 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="576-pf-rBg">
-                                <rect key="frame" x="333" y="74.5" width="17" height="30"/>
-                                <fontDescription key="fontDescription" name="Bazaronite" family="Bazaronite" pointSize="25"/>
-                                <color key="textColor" name="boosterLabel"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="IOt-Vq-NdU">
-                                <rect key="frame" x="64" y="74.5" width="17" height="30"/>
-                                <fontDescription key="fontDescription" name="Bazaronite" family="Bazaronite" pointSize="25"/>
-                                <color key="textColor" name="boosterLabel"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0h 0m" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DK1-7W-5Tf">
-                                <rect key="frame" x="162.5" y="74.5" width="92.5" height="30"/>
-                                <fontDescription key="fontDescription" name="Bazaronite" family="Bazaronite" pointSize="25"/>
-                                <color key="textColor" name="boosterLabel"/>
-                                <nil key="highlightedColor"/>
-                            </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ssn-6d-STD" customClass="GradientLabel" customModule="Booster" customModuleProvider="target">
                                 <rect key="frame" x="182" y="343.5" width="66.5" height="119"/>
                                 <fontDescription key="fontDescription" name="Bazaronite" family="Bazaronite" pointSize="100"/>
-                                <color key="textColor" name="boosterLabel"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="kcal" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="F17-N7-fTR">
-                                <rect key="frame" x="56" y="114.5" width="28.5" height="22"/>
-                                <fontDescription key="fontDescription" name="NotoSansKR-Regular" family="Noto Sans KR" pointSize="15"/>
-                                <color key="textColor" name="boosterLabel"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="time active" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="w4J-fM-4aL">
-                                <rect key="frame" x="168.5" y="114.5" width="77.5" height="22"/>
-                                <fontDescription key="fontDescription" name="NotoSansKR-Regular" family="Noto Sans KR" pointSize="15"/>
-                                <color key="textColor" name="boosterLabel"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="km" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xHn-DV-MaZ">
-                                <rect key="frame" x="329" y="114.5" width="22.5" height="22"/>
-                                <fontDescription key="fontDescription" name="NotoSansKR-Regular" family="Noto Sans KR" pointSize="15"/>
                                 <color key="textColor" name="boosterLabel"/>
                                 <nil key="highlightedColor"/>
                             </label>
@@ -86,32 +50,30 @@
                                 <rect key="frame" x="30" y="648" width="354" height="135"/>
                                 <color key="backgroundColor" name="boosterBackground"/>
                             </view>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="SqD-jA-YKV" customClass="ThreeColumnRecordView" customModule="Booster" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="64" width="414" height="100"/>
+                                <color key="backgroundColor" name="boosterBackground"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="100" id="5GG-df-P1i"/>
+                                </constraints>
+                            </view>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
                         <color key="backgroundColor" name="boosterBackground"/>
                         <constraints>
                             <constraint firstItem="FqG-gg-gIl" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="30" id="4No-r3-mb8"/>
-                            <constraint firstItem="576-pf-rBg" firstAttribute="centerX" secondItem="5EZ-qb-Rvc" secondAttribute="centerX" multiplier="1.65" id="4gU-Ot-wec"/>
-                            <constraint firstItem="F17-N7-fTR" firstAttribute="top" secondItem="IOt-Vq-NdU" secondAttribute="bottom" constant="10" id="5KZ-2Y-8L3"/>
-                            <constraint firstItem="IOt-Vq-NdU" firstAttribute="centerY" secondItem="5EZ-qb-Rvc" secondAttribute="centerY" multiplier="0.2" id="61J-pS-Qju"/>
                             <constraint firstItem="TZn-KZ-HUf" firstAttribute="centerX" secondItem="5EZ-qb-Rvc" secondAttribute="centerX" id="8Jl-ms-AJ2"/>
                             <constraint firstItem="Ssn-6d-STD" firstAttribute="centerY" secondItem="5EZ-qb-Rvc" secondAttribute="centerY" multiplier="0.9" id="8Vn-4G-Ip2"/>
-                            <constraint firstItem="w4J-fM-4aL" firstAttribute="centerX" secondItem="5EZ-qb-Rvc" secondAttribute="centerX" id="Fpl-0F-OB4"/>
                             <constraint firstItem="TZn-KZ-HUf" firstAttribute="centerY" secondItem="5EZ-qb-Rvc" secondAttribute="centerY" multiplier="1.1" id="KfM-fJ-FOK"/>
-                            <constraint firstItem="DK1-7W-5Tf" firstAttribute="centerX" secondItem="5EZ-qb-Rvc" secondAttribute="centerX" multiplier="1.008" id="Mj9-dP-EXh"/>
+                            <constraint firstItem="SqD-jA-YKV" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" id="NMB-Yt-h1a"/>
                             <constraint firstItem="TBK-bI-lVF" firstAttribute="top" secondItem="FqG-gg-gIl" secondAttribute="bottom" constant="10" id="RaE-Jb-piO"/>
-                            <constraint firstItem="DK1-7W-5Tf" firstAttribute="centerY" secondItem="5EZ-qb-Rvc" secondAttribute="centerY" multiplier="0.2" id="TlP-AN-wVg"/>
                             <constraint firstItem="FqG-gg-gIl" firstAttribute="centerY" secondItem="5EZ-qb-Rvc" secondAttribute="centerY" multiplier="1.4" id="TxX-2f-8JI"/>
                             <constraint firstItem="TBK-bI-lVF" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="30" id="Vb6-hK-AQV"/>
-                            <constraint firstItem="xHn-DV-MaZ" firstAttribute="centerX" secondItem="576-pf-rBg" secondAttribute="centerX" multiplier="0.996" id="Zh7-Ct-618"/>
-                            <constraint firstItem="IOt-Vq-NdU" firstAttribute="centerX" secondItem="5EZ-qb-Rvc" secondAttribute="centerX" multiplier="0.35" id="abj-cV-5f4"/>
                             <constraint firstItem="Ssn-6d-STD" firstAttribute="centerX" secondItem="5EZ-qb-Rvc" secondAttribute="centerX" multiplier="1.04" id="cvj-ls-Jg8"/>
+                            <constraint firstItem="SqD-jA-YKV" firstAttribute="top" secondItem="vDu-zF-Fre" secondAttribute="top" constant="20" id="fRa-i7-tmI"/>
                             <constraint firstItem="TBK-bI-lVF" firstAttribute="bottom" secondItem="vDu-zF-Fre" secondAttribute="bottom" constant="-30" id="hOr-jE-9hy"/>
-                            <constraint firstItem="xHn-DV-MaZ" firstAttribute="top" secondItem="576-pf-rBg" secondAttribute="bottom" constant="10" id="jbE-D7-EUl"/>
-                            <constraint firstItem="w4J-fM-4aL" firstAttribute="top" secondItem="DK1-7W-5Tf" secondAttribute="bottom" constant="10" id="mad-Fk-COx"/>
-                            <constraint firstItem="576-pf-rBg" firstAttribute="centerY" secondItem="5EZ-qb-Rvc" secondAttribute="centerY" multiplier="0.2" id="non-pq-QWR"/>
+                            <constraint firstAttribute="trailing" secondItem="SqD-jA-YKV" secondAttribute="trailing" id="qxK-In-OMO"/>
                             <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="TBK-bI-lVF" secondAttribute="trailing" constant="30" id="u28-3r-V2B"/>
-                            <constraint firstItem="F17-N7-fTR" firstAttribute="centerX" secondItem="IOt-Vq-NdU" secondAttribute="centerX" multiplier="0.97" id="uKr-hb-i34"/>
                         </constraints>
                     </view>
                     <tabBarItem key="tabBarItem" title="" image="home" selectedImage="home" id="ZN1-p6-8Xg"/>
@@ -119,9 +81,7 @@
                     <connections>
                         <outlet property="goalLabel" destination="TZn-KZ-HUf" id="TU4-Ra-AQ7"/>
                         <outlet property="hourlyBarChartView" destination="TBK-bI-lVF" id="lkg-ka-wVa"/>
-                        <outlet property="kcalLabel" destination="IOt-Vq-NdU" id="mHf-Oa-YZ3"/>
-                        <outlet property="kmLabel" destination="576-pf-rBg" id="Xhi-iJ-LE1"/>
-                        <outlet property="timeActiveLabel" destination="DK1-7W-5Tf" id="gcb-mb-QTF"/>
+                        <outlet property="recordView" destination="SqD-jA-YKV" id="1a6-SE-gsK"/>
                         <outlet property="todayTotalStepCountLabel" destination="Ssn-6d-STD" id="gdw-or-0vE"/>
                     </connections>
                 </viewController>

--- a/Booster/Booster/Usecases/DetailFeedUsecase.swift
+++ b/Booster/Booster/Usecases/DetailFeedUsecase.swift
@@ -42,8 +42,8 @@ final class DetailFeedUsecase: DetailFeedUsecaseProtocol {
     func update(milestones: [Milestone], predicate: NSPredicate) -> Observable<Void> {
         guard let milestones = try? NSKeyedArchiver.archivedData(withRootObject: milestones, requiringSecureCoding: false)
         else {
-            return Observable.create { observable in
-                observable.on(.error(TrackingError.modelError))
+            return Observable.create { observer in
+                observer.on(.error(TrackingError.modelError))
                 return Disposables.create()
             }
         }

--- a/Booster/Booster/Usecases/DetailFeedUsecase.swift
+++ b/Booster/Booster/Usecases/DetailFeedUsecase.swift
@@ -43,7 +43,7 @@ final class DetailFeedUsecase: DetailFeedUsecaseProtocol {
         guard let milestones = try? NSKeyedArchiver.archivedData(withRootObject: milestones, requiringSecureCoding: false)
         else {
             return Observable.create { observer in
-                observer.on(.error(TrackingError.modelError))
+                observer.onError(TrackingError.modelError)
                 return Disposables.create()
             }
         }

--- a/Booster/Booster/ViewControllers/Feed/DetailFeedViewController.swift
+++ b/Booster/Booster/ViewControllers/Feed/DetailFeedViewController.swift
@@ -74,16 +74,14 @@ final class DetailFeedViewController: UIViewController, BaseViewControllerTempla
         viewModel.isDeletedMilestone
             .observe(on: MainScheduler.instance)
             .bind { [weak self] isDeleted in
-                if isDeleted { self?.presentAlertController(title: "삭제 완료", message: "마일스톤을 삭제했어요") }
-                else { self?.presentAlertController(title: "삭제 오류", message: "마일스톤을 삭제하는 데 문제가 생겼어요\n잠시 후 다시 시도해주세요") }
+                if isDeleted { self?.presentAlertController(title: "삭제 완료", message: "마일스톤을 삭제했어요") } else { self?.presentAlertController(title: "삭제 오류", message: "마일스톤을 삭제하는 데 문제가 생겼어요\n잠시 후 다시 시도해주세요") }
             }
             .disposed(by: disposeBag)
 
         viewModel.isDeletedAll
             .observe(on: MainScheduler.instance)
             .bind { [weak self] isDeleted in
-                if isDeleted { self?.presentDeleteAlertController() }
-                else { self?.presentAlertController(title: "삭제 실패", message: "산책 기록을 삭제할 수 없어요\n잠시 후 다시 시도해주세요") }
+                if isDeleted { self?.presentDeleteAlertController() } else { self?.presentAlertController(title: "삭제 실패", message: "산책 기록을 삭제할 수 없어요\n잠시 후 다시 시도해주세요") }
             }
             .disposed(by: disposeBag)
     }

--- a/Booster/Booster/ViewControllers/Home/HomeViewController.swift
+++ b/Booster/Booster/ViewControllers/Home/HomeViewController.swift
@@ -8,6 +8,8 @@ final class HomeViewController: UIViewController {
     @IBOutlet private weak var kcalLabel: UILabel!
     @IBOutlet private weak var timeActiveLabel: UILabel!
     @IBOutlet private weak var kmLabel: UILabel!
+    @IBOutlet private weak var recordView: ThreeColumnRecordView!
+
     @IBOutlet private weak var todayTotalStepCountLabel: GradientLabel!
     @IBOutlet private weak var goalLabel: UILabel!
     @IBOutlet private weak var hourlyBarChartView: ChartView!
@@ -62,9 +64,10 @@ final class HomeViewController: UIViewController {
         else { return }
         if stepRatios.count == 0 { return }
 
-        kmLabel.text = String(format: "%.2f", homeModel.km)
-        kcalLabel.text = "\(homeModel.kcal)"
-        timeActiveLabel.text = homeModel.activeTime.stringToMinutesAndSeconds()
+        recordView.configureLabels(kcal: "\(homeModel.kcal)",
+                                   time: homeModel.activeTime.stringToMinutesAndSeconds(),
+                                   km: String(format: "%.2f", homeModel.km),
+                                   timeLabelName: "time active")
         hourlyBarChartView.drawChart(stepRatios: stepRatios.map { CGFloat($0) }, strings: ["0", "6", "12", "18"])
         todayTotalStepCountLabel.drawLabel(step: homeModel.totalStepCount, ratio: homeModel.gradientRatio())
     }

--- a/Booster/Booster/ViewControllers/Home/HomeViewController.swift
+++ b/Booster/Booster/ViewControllers/Home/HomeViewController.swift
@@ -5,9 +5,6 @@ import RxSwift
 
 final class HomeViewController: UIViewController {
     // MARK: - @IBOutlet
-    @IBOutlet private weak var kcalLabel: UILabel!
-    @IBOutlet private weak var timeActiveLabel: UILabel!
-    @IBOutlet private weak var kmLabel: UILabel!
     @IBOutlet private weak var recordView: ThreeColumnRecordView!
 
     @IBOutlet private weak var todayTotalStepCountLabel: GradientLabel!

--- a/Booster/Booster/ViewModels/Feed/DetailFeedViewModel.swift
+++ b/Booster/Booster/ViewModels/Feed/DetailFeedViewModel.swift
@@ -30,14 +30,8 @@ final class DetailFeedViewModel {
 
     // MARK: - Functions
     func milestone(at coordinate: Coordinate) -> Milestone? {
-        let target = trackingModel.value.milestones.first(where: { value in
-            return value.coordinate == coordinate
-        })
-
-        return target
+        return trackingModel.value.milestones.filter { $0.coordinate == coordinate }.first
     }
-
-    func reset() { gradientColorOffset = -1 }
 
     func remove(of milestone: Milestone) {
         guard let index = trackingModel.value.milestones.firstIndex(of: milestone)
@@ -83,9 +77,13 @@ final class DetailFeedViewModel {
         return nil
     }
 
-    func offsetOfGradientColor() -> Int {
+    func offsetOfGradientColorCoordinate() -> Coordinate? {
         gradientColorOffset += 1
-        return gradientColorOffset
+        return trackingModel.value.coordinates[gradientColorOffset] ?? nil
+    }
+
+    func indexRatioOfCoordinate(_ coordinate: Coordinate) -> Double? {
+        return trackingModel.value.coordinates.indexRatio(coordinate)
     }
 
     func fetchDetailFeedList() {

--- a/Booster/Booster/Views/Feed/DetailFeedMapView.swift
+++ b/Booster/Booster/Views/Feed/DetailFeedMapView.swift
@@ -11,13 +11,13 @@ final class DetailFeedMapView: BoosterMapView {
     override init(frame: CGRect) {
         super.init(frame: frame)
 
-        configure()
+        configureLayerStyle()
     }
 
     required init?(coder: NSCoder) {
         super.init(coder: coder)
 
-        configure()
+        configureLayerStyle()
     }
 
     func configure(trackingModel value: TrackingModel) {
@@ -47,8 +47,9 @@ final class DetailFeedMapView: BoosterMapView {
         return newAnnotationView
     }
 
-    private func configure() {
-        layer.cornerRadius = frame.height / 17
+    private func configureLayerStyle() {
+        let cornerRadiusRatio: CGFloat = 17
+        layer.cornerRadius = frame.height / cornerRadiusRatio
     }
 
     private func configureMilestones(_ milestones: [Milestone]) {

--- a/Booster/Booster/Views/Feed/DetailFeedMapView.swift
+++ b/Booster/Booster/Views/Feed/DetailFeedMapView.swift
@@ -20,10 +20,6 @@ final class DetailFeedMapView: BoosterMapView {
         configure()
     }
 
-    private func configure() {
-        layer.cornerRadius = frame.height / 17
-    }
-
     func configure(trackingModel value: TrackingModel) {
         let centerLocation = value.coordinates.center()
         setRegion(to: CLLocation(latitude: centerLocation.latitude ?? 0, longitude: centerLocation.longitude ?? 0), meterRadius: value.distance * 1000 + 50)
@@ -49,6 +45,10 @@ final class DetailFeedMapView: BoosterMapView {
         newAnnotationView.isUserInteractionEnabled = false
         newAnnotationView.layer.cornerRadius = newAnnotationView.frame.height / 2
         return newAnnotationView
+    }
+    
+    private func configure() {
+        layer.cornerRadius = frame.height / 17
     }
 
     private func configureMilestones(_ milestones: [Milestone]) {

--- a/Booster/Booster/Views/Tracking/TrackingMapView.swift
+++ b/Booster/Booster/Views/Tracking/TrackingMapView.swift
@@ -90,10 +90,10 @@ class TrackingMapView: BoosterMapView {
                 }
                 prevCoordinate = coordinate
 
-                if let gradientColor = self?.gradientColorOfCoordinate(at: coordinate,
-                                                                 coordinates: coordinates,
-                                                                 from: .boosterBackground,
-                                                                 to: .boosterOrange) {
+                if let ratio = coordinates.indexRatio(coordinate),
+                   let gradientColor = self?.gradientColorOfCoordinate(indexRatio: ratio,
+                                                                       from: .boosterBackground,
+                                                                       to: .boosterOrange) {
                     gradientColor.set()
                     context.strokePath()
                 }

--- a/Booster/Booster/Views/Utils/BoosterMapView.swift
+++ b/Booster/Booster/Views/Utils/BoosterMapView.swift
@@ -15,6 +15,18 @@ class BoosterMapView: MKMapView {
         case endDot
     }
 
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        configure()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+
+        configure()
+    }
+
     func setRegion(to location: CLLocation, meterRadius: Double) {
         let coordinateRegion = MKCoordinateRegion(center: location.coordinate,
                                                   latitudinalMeters: meterRadius * 2,
@@ -57,5 +69,9 @@ class BoosterMapView: MKMapView {
         let blue = fromColor.blueValue + ((toColor.blueValue - fromColor.blueValue) * percentOfPathProgress)
 
         return UIColor(red: red, green: green, blue: blue, alpha: 1)
+    }
+    
+    private func configure() {
+        isPitchEnabled = false
     }
 }

--- a/Booster/Booster/Views/Utils/BoosterMapView.swift
+++ b/Booster/Booster/Views/Utils/BoosterMapView.swift
@@ -55,22 +55,16 @@ class BoosterMapView: MKMapView {
         addOverlay(line)
     }
 
-    func gradientColorOfCoordinate(at coordinate: Coordinate,
-                                   coordinates: Coordinates,
+    func gradientColorOfCoordinate(indexRatio percentOfPathProgress: Double,
                                    from fromColor: UIColor,
                                    to toColor: UIColor) -> UIColor? {
-        guard let indexOfTargetCoordinate = coordinates.firstIndex(of: coordinate)
-        else { return nil }
-
-        let percentOfPathProgress = Double(indexOfTargetCoordinate) / Double(coordinates.count)
-
         let red = fromColor.redValue + ((toColor.redValue - fromColor.redValue) * percentOfPathProgress)
         let green = fromColor.greenValue + ((toColor.greenValue - fromColor.greenValue) * percentOfPathProgress)
         let blue = fromColor.blueValue + ((toColor.blueValue - fromColor.blueValue) * percentOfPathProgress)
 
         return UIColor(red: red, green: green, blue: blue, alpha: 1)
     }
-    
+
     private func configure() {
         isPitchEnabled = false
     }

--- a/Booster/Booster/Views/Utils/ThreeColumnRecordView.swift
+++ b/Booster/Booster/Views/Utils/ThreeColumnRecordView.swift
@@ -90,7 +90,7 @@ final class ThreeColumnRecordView: UIView {
 
         kcalLabel.translatesAutoresizingMaskIntoConstraints = false
         kcalLabel.topAnchor.constraint(equalTo: kcalRecordLabel.bottomAnchor, constant: 5).isActive = true
-        kcalLabel.centerXAnchor.constraint(equalToSystemSpacingAfter: kcalRecordLabel.centerXAnchor, multiplier: 0.97).isActive = true
+        kcalLabel.widthAnchor.constraint(equalTo: kcalRecordLabel.widthAnchor, multiplier: 0.97).isActive = true
 
         timeRecordLabel.translatesAutoresizingMaskIntoConstraints = false
         timeRecordLabel.widthAnchor.constraint(equalTo: widthAnchor, multiplier: 1.008).isActive = true
@@ -106,7 +106,7 @@ final class ThreeColumnRecordView: UIView {
         kmRecordLabel.centerYAnchor.constraint(equalTo: kcalRecordLabel.centerYAnchor).isActive = true
 
         kmLabel.translatesAutoresizingMaskIntoConstraints = false
-        kmLabel.centerXAnchor.constraint(equalToSystemSpacingAfter: kmRecordLabel.centerXAnchor, multiplier: 0.996).isActive = true
+        kmLabel.widthAnchor.constraint(equalTo: kmRecordLabel.widthAnchor, multiplier: 0.996).isActive = true
         kmLabel.centerYAnchor.constraint(equalTo: kcalLabel.centerYAnchor).isActive = true
     }
 }

--- a/Booster/Booster/Views/Utils/ThreeColumnRecordView.swift
+++ b/Booster/Booster/Views/Utils/ThreeColumnRecordView.swift
@@ -60,13 +60,13 @@ final class ThreeColumnRecordView: UIView {
     override init(frame: CGRect) {
         super.init(frame: frame)
 
-        configure()
+        configureLayout()
     }
 
     required init?(coder: NSCoder) {
         super.init(coder: coder)
 
-        configure()
+        configureLayout()
     }
 
     func configureLabels(kcal: String, time: String, km: String, timeLabelName: String? = nil) {
@@ -76,7 +76,7 @@ final class ThreeColumnRecordView: UIView {
         timeLabel.text = timeLabelName ?? "time"
     }
 
-    private func configure() {
+    private func configureLayout() {
         addSubview(kcalRecordLabel)
         addSubview(timeRecordLabel)
         addSubview(kmRecordLabel)

--- a/Booster/Booster/Views/Utils/ThreeColumnRecordView.swift
+++ b/Booster/Booster/Views/Utils/ThreeColumnRecordView.swift
@@ -1,0 +1,112 @@
+//
+//  ThreeColumnRecordView.swift
+//  Booster
+//
+//  Created by hiju on 2021/11/28.
+//
+
+import UIKit
+
+final class ThreeColumnRecordView: UIView {
+    private var kcalRecordLabel: UILabel = {
+        let label = UILabel()
+        label.font = .bazaronite(size: 25)
+        label.text = "0"
+        label.textColor = .boosterLabel
+        label.textAlignment = .center
+        return label
+    }()
+    private var timeRecordLabel: UILabel = {
+        let label = UILabel()
+        label.font = .bazaronite(size: 25)
+        label.text = "0h 0m"
+        label.textColor = .boosterLabel
+        label.textAlignment = .center
+        return label
+    }()
+    private var kmRecordLabel: UILabel = {
+        let label = UILabel()
+        label.font = .bazaronite(size: 25)
+        label.text = "0.0"
+        label.textColor = .boosterLabel
+        label.textAlignment = .center
+        return label
+    }()
+    private var kcalLabel: UILabel = {
+        let label = UILabel()
+        label.font = .notoSansKR(.light, 15)
+        label.text = "kcal"
+        label.textColor = .boosterLabel
+        label.textAlignment = .center
+        return label
+    }()
+    private var timeLabel: UILabel = {
+        let label = UILabel()
+        label.font = .notoSansKR(.light, 15)
+        label.text = "time"
+        label.textColor = .boosterLabel
+        label.textAlignment = .center
+        return label
+    }()
+    private var kmLabel: UILabel = {
+        let label = UILabel()
+        label.font = .notoSansKR(.light, 15)
+        label.text = "km"
+        label.textColor = .boosterLabel
+        label.textAlignment = .center
+        return label
+    }()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        configure()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+
+        configure()
+    }
+
+    func configureLabels(kcal: String, time: String, km: String, timeLabelName: String? = nil) {
+        kcalRecordLabel.text = kcal
+        timeRecordLabel.text = time
+        kmRecordLabel.text = km
+        timeLabel.text = timeLabelName ?? "time"
+    }
+
+    private func configure() {
+        addSubview(kcalRecordLabel)
+        addSubview(timeRecordLabel)
+        addSubview(kmRecordLabel)
+        addSubview(kcalLabel)
+        addSubview(timeLabel)
+        addSubview(kmLabel)
+
+        kcalRecordLabel.translatesAutoresizingMaskIntoConstraints = false
+        kcalRecordLabel.widthAnchor.constraint(equalTo: widthAnchor, multiplier: 0.35).isActive = true
+        kcalRecordLabel.topAnchor.constraint(equalTo: topAnchor, constant: 5).isActive = true
+
+        kcalLabel.translatesAutoresizingMaskIntoConstraints = false
+        kcalLabel.topAnchor.constraint(equalTo: kcalRecordLabel.bottomAnchor, constant: 5).isActive = true
+        kcalLabel.centerXAnchor.constraint(equalToSystemSpacingAfter: kcalRecordLabel.centerXAnchor, multiplier: 0.97).isActive = true
+
+        timeRecordLabel.translatesAutoresizingMaskIntoConstraints = false
+        timeRecordLabel.widthAnchor.constraint(equalTo: widthAnchor, multiplier: 1.008).isActive = true
+
+        timeRecordLabel.centerYAnchor.constraint(equalTo: kcalRecordLabel.centerYAnchor).isActive = true
+
+        timeLabel.translatesAutoresizingMaskIntoConstraints = false
+        timeLabel.centerXAnchor.constraint(equalTo: centerXAnchor).isActive = true
+        timeLabel.centerYAnchor.constraint(equalTo: kcalLabel.centerYAnchor).isActive = true
+
+        kmRecordLabel.translatesAutoresizingMaskIntoConstraints = false
+        kmRecordLabel.widthAnchor.constraint(equalTo: widthAnchor, multiplier: 1.65).isActive = true
+        kmRecordLabel.centerYAnchor.constraint(equalTo: kcalRecordLabel.centerYAnchor).isActive = true
+
+        kmLabel.translatesAutoresizingMaskIntoConstraints = false
+        kmLabel.centerXAnchor.constraint(equalToSystemSpacingAfter: kmRecordLabel.centerXAnchor, multiplier: 0.996).isActive = true
+        kmLabel.centerYAnchor.constraint(equalTo: kcalLabel.centerYAnchor).isActive = true
+    }
+}


### PR DESCRIPTION
### 작업 내용
- DetailFeedVC, VM, model 작업
- milestone, coordinate 배열 구조체 타입 변경되면서 메소드 로직 분리
- 세개 3열 record ( kcal, time, km 커스텀 뷰) 생성 -> 재사용성 높임. 홈/피드 모두 사용 가능. (트래킹도 사용할수있을듯합니다)


### 체크리스트
- [x] #104 
- [x] #185  

### 구현 설명
- VC에 있는 뷰작업들을 다 뷰로 옮겨서 VC의 역할을 좀 줄였습니다.
-  km, kcal, time의 기록을 담고 있는 UI뷰를 커스텀뷰를 만들어 , 다른 화면에서도 재사용성을 높였습니다.
- 기존 VC에서 가지고 있던 colors UIcolor 배열을 없앴습니다. 따로, milestone과 coordinate구조체에 연결시켰습니다.
- 공유할 때, 스크린샷뷰를 따로 UIView extension에서 잡아주도록 밖으로 빼내었습니다.

### 하고싶은 말
