### PR TITLE
[A] iPhone SE 뷰 짤리는 버그 수정

### DIFF
--- a/Booster/Booster.xcodeproj/project.pbxproj
+++ b/Booster/Booster.xcodeproj/project.pbxproj
@@ -22,8 +22,10 @@
 		28C9708A275283FA005BD7BC /* UIView+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28C97089275283FA005BD7BC /* UIView+Extension.swift */; };
 		28C9708C27528CFC005BD7BC /* ThreeColumnRecordView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28C9708B27528CFC005BD7BC /* ThreeColumnRecordView.swift */; };
 		28C970922753D10E005BD7BC /* ToastView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28C970912753D10E005BD7BC /* ToastView.swift */; };
-		37852ACF273C27F100BA3D67 /* StatisticsModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37852ACE273C27F100BA3D67 /* StatisticsModelTests.swift */; };
+		373B1A202754B1DB006D826E /* StepStatitstics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BE60F6327464E0300B4EFB8 /* StepStatitstics.swift */; };
 		37852AD8273C2D0B00BA3D67 /* StepStatisticsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37852AD7273C2D0B00BA3D67 /* StepStatisticsTests.swift */; };
+		37952E1A2754B4D000D1B0E3 /* StatisticsUsecase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BE60F6027464DE700B4EFB8 /* StatisticsUsecase.swift */; };
+		37952E1C2754D82D00D1B0E3 /* HealthKitManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37FD1AED274D1D6600FAB0CC /* HealthKitManager.swift */; };
 		379E3C57273BC182002B0B15 /* ChartView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 379E3C56273BC182002B0B15 /* ChartView.swift */; };
 		37AE2EA8274F5401003F5FF7 /* GradientLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37AE2EA7274F5401003F5FF7 /* GradientLabel.swift */; };
 		37C3F67E275267C8009AE5D5 /* StatisticsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37C3F67D275267C8009AE5D5 /* StatisticsViewModelTests.swift */; };
@@ -47,8 +49,6 @@
 		3B31B61B2741097E009D9190 /* HealthStoreManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA614F532733CDAA00B090D9 /* HealthStoreManager.swift */; };
 		3B31B61C2741098C009D9190 /* CoreDataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA614F262733CDAA00B090D9 /* CoreDataManager.swift */; };
 		3B31B61D27410997009D9190 /* StatisticsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA614F162733CDAA00B090D9 /* StatisticsViewModel.swift */; };
-		3B31B61E274109A5009D9190 /* BoosterObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA614F3C2733CDAA00B090D9 /* BoosterObservable.swift */; };
-		3B31B61F274109AF009D9190 /* HealthStoreManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA614F532733CDAA00B090D9 /* HealthStoreManager.swift */; };
 		3B31B62127413664009D9190 /* FeedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B31B62027413664009D9190 /* FeedList.swift */; };
 		3B37B999274366A8001EB120 /* EnrollViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B37B998274366A8001EB120 /* EnrollViewModel.swift */; };
 		3B37B99C274371B9001EB120 /* GenderEnrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B37B99B274371B9001EB120 /* GenderEnrollView.swift */; };
@@ -1179,11 +1179,11 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				37852ACF273C27F100BA3D67 /* StatisticsModelTests.swift in Sources */,
+				37952E1A2754B4D000D1B0E3 /* StatisticsUsecase.swift in Sources */,
+				373B1A202754B1DB006D826E /* StepStatitstics.swift in Sources */,
 				37C3F67E275267C8009AE5D5 /* StatisticsViewModelTests.swift in Sources */,
-				3B31B61F274109AF009D9190 /* HealthStoreManager.swift in Sources */,
-				3B31B61E274109A5009D9190 /* BoosterObservable.swift in Sources */,
 				37852AD8273C2D0B00BA3D67 /* StepStatisticsTests.swift in Sources */,
+				37952E1C2754D82D00D1B0E3 /* HealthKitManager.swift in Sources */,
 				3B31B61D27410997009D9190 /* StatisticsViewModel.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Booster/Booster.xcodeproj/xcshareddata/xcschemes/Booster.xcscheme
+++ b/Booster/Booster.xcodeproj/xcshareddata/xcschemes/Booster.xcscheme
@@ -26,7 +26,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -37,16 +38,11 @@
                BlueprintName = "StatisticsTests"
                ReferencedContainer = "container:Booster.xcodeproj">
             </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "3B31B60427410470009D9190"
-               BuildableName = "TrackingProgressTests.xctest"
-               BlueprintName = "TrackingProgressTests"
-               ReferencedContainer = "container:Booster.xcodeproj">
-            </BuildableReference>
+            <SkippedTests>
+               <Test
+                  Identifier = "StatisticsModelTests">
+               </Test>
+            </SkippedTests>
          </TestableReference>
          <TestableReference
             skipped = "NO">
@@ -65,26 +61,6 @@
                BlueprintIdentifier = "FAB252852753C3CE00A4FC5B"
                BuildableName = "CoordinateTEsts.xctest"
                BlueprintName = "CoordinateTEsts"
-               ReferencedContainer = "container:Booster.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "FAB252BA2753C5EB00A4FC5B"
-               BuildableName = "CoordinateTests.xctest"
-               BlueprintName = "CoordinateTests"
-               ReferencedContainer = "container:Booster.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "FAB252C82753D1AF00A4FC5B"
-               BuildableName = "MilestoneTests.xctest"
-               BlueprintName = "MilestoneTests"
                ReferencedContainer = "container:Booster.xcodeproj">
             </BuildableReference>
          </TestableReference>

--- a/Booster/Booster/Models/StepStatitstics.swift
+++ b/Booster/Booster/Models/StepStatitstics.swift
@@ -54,7 +54,7 @@ struct StepStatisticsCollection {
         return stepStatisticsCollection.reduce(0) { $0 + $1.step } / stepStatisticsCollection.count
     }
 
-    func stepRatios() -> [Float]? {
+    func stepRatios() -> [Float] {
         guard let maxStepStatistics = maxStepStatistics(),
               maxStepStatistics.step > 0
         else { return [Float](repeating: 0, count: stepStatisticsCollection.count) }

--- a/Booster/Booster/Storyboards/Home.storyboard
+++ b/Booster/Booster/Storyboards/Home.storyboard
@@ -41,7 +41,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="TBK-bI-lVF" customClass="ChartView" customModule="Booster" customModuleProvider="target">
-                                <rect key="frame" x="30" y="673" width="354" height="140"/>
+                                <rect key="frame" x="30" y="643" width="354" height="140"/>
                                 <color key="backgroundColor" name="boosterBackground"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="140" id="lXh-fR-AcS"/>
@@ -61,7 +61,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="hourly" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FqG-gg-gIl">
-                                <rect key="frame" x="30" y="641" width="45.5" height="22"/>
+                                <rect key="frame" x="30" y="611" width="45.5" height="22"/>
                                 <fontDescription key="fontDescription" name="NotoSansKR-Regular" family="Noto Sans KR" pointSize="15"/>
                                 <color key="textColor" name="boosterLabel"/>
                                 <nil key="highlightedColor"/>
@@ -73,7 +73,7 @@
                             <constraint firstItem="FqG-gg-gIl" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="30" id="4No-r3-mb8"/>
                             <constraint firstItem="TZn-KZ-HUf" firstAttribute="centerX" secondItem="5EZ-qb-Rvc" secondAttribute="centerX" id="8Jl-ms-AJ2"/>
                             <constraint firstItem="Ssn-6d-STD" firstAttribute="centerY" secondItem="5EZ-qb-Rvc" secondAttribute="centerY" multiplier="0.9" id="8Vn-4G-Ip2"/>
-                            <constraint firstItem="TBK-bI-lVF" firstAttribute="bottom" secondItem="vDu-zF-Fre" secondAttribute="bottom" id="9fv-rE-kuO"/>
+                            <constraint firstItem="TBK-bI-lVF" firstAttribute="bottom" secondItem="vDu-zF-Fre" secondAttribute="bottom" constant="-30" id="9fv-rE-kuO"/>
                             <constraint firstItem="fPg-k0-zrM" firstAttribute="centerX" secondItem="5EZ-qb-Rvc" secondAttribute="centerX" id="FTo-pS-Waa"/>
                             <constraint firstItem="TZn-KZ-HUf" firstAttribute="centerY" secondItem="5EZ-qb-Rvc" secondAttribute="centerY" multiplier="1.1" id="KfM-fJ-FOK"/>
                             <constraint firstItem="SqD-jA-YKV" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" id="NMB-Yt-h1a"/>

--- a/Booster/Booster/Storyboards/Home.storyboard
+++ b/Booster/Booster/Storyboards/Home.storyboard
@@ -41,8 +41,11 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="TBK-bI-lVF" customClass="ChartView" customModule="Booster" customModuleProvider="target">
-                                <rect key="frame" x="30" y="648.5" width="354" height="134.5"/>
+                                <rect key="frame" x="30" y="673" width="354" height="140"/>
                                 <color key="backgroundColor" name="boosterBackground"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="140" id="lXh-fR-AcS"/>
+                                </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="SqD-jA-YKV" customClass="ThreeColumnRecordView" customModule="Booster" customModuleProvider="target">
                                 <rect key="frame" x="0.0" y="64" width="414" height="100"/>
@@ -58,7 +61,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="hourly" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FqG-gg-gIl">
-                                <rect key="frame" x="30" y="616.5" width="45.5" height="22"/>
+                                <rect key="frame" x="30" y="641" width="45.5" height="22"/>
                                 <fontDescription key="fontDescription" name="NotoSansKR-Regular" family="Noto Sans KR" pointSize="15"/>
                                 <color key="textColor" name="boosterLabel"/>
                                 <nil key="highlightedColor"/>
@@ -70,8 +73,7 @@
                             <constraint firstItem="FqG-gg-gIl" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="30" id="4No-r3-mb8"/>
                             <constraint firstItem="TZn-KZ-HUf" firstAttribute="centerX" secondItem="5EZ-qb-Rvc" secondAttribute="centerX" id="8Jl-ms-AJ2"/>
                             <constraint firstItem="Ssn-6d-STD" firstAttribute="centerY" secondItem="5EZ-qb-Rvc" secondAttribute="centerY" multiplier="0.9" id="8Vn-4G-Ip2"/>
-                            <constraint firstItem="vDu-zF-Fre" firstAttribute="bottom" secondItem="TBK-bI-lVF" secondAttribute="bottom" constant="30" id="9fv-rE-kuO"/>
-                            <constraint firstItem="FqG-gg-gIl" firstAttribute="centerY" secondItem="5EZ-qb-Rvc" secondAttribute="centerY" multiplier="1.4" id="Amu-ax-XIE"/>
+                            <constraint firstItem="TBK-bI-lVF" firstAttribute="bottom" secondItem="vDu-zF-Fre" secondAttribute="bottom" id="9fv-rE-kuO"/>
                             <constraint firstItem="fPg-k0-zrM" firstAttribute="centerX" secondItem="5EZ-qb-Rvc" secondAttribute="centerX" id="FTo-pS-Waa"/>
                             <constraint firstItem="TZn-KZ-HUf" firstAttribute="centerY" secondItem="5EZ-qb-Rvc" secondAttribute="centerY" multiplier="1.1" id="KfM-fJ-FOK"/>
                             <constraint firstItem="SqD-jA-YKV" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" id="NMB-Yt-h1a"/>
@@ -79,11 +81,9 @@
                             <constraint firstItem="Ssn-6d-STD" firstAttribute="centerX" secondItem="5EZ-qb-Rvc" secondAttribute="centerX" multiplier="1.04" id="cvj-ls-Jg8"/>
                             <constraint firstItem="SqD-jA-YKV" firstAttribute="top" secondItem="vDu-zF-Fre" secondAttribute="top" constant="20" id="fRa-i7-tmI"/>
                             <constraint firstItem="fPg-k0-zrM" firstAttribute="top" secondItem="TZn-KZ-HUf" secondAttribute="bottom" constant="4" id="iTP-9b-eei"/>
-                            <constraint firstAttribute="centerY" secondItem="5EZ-qb-Rvc" secondAttribute="centerY" multiplier="0.2" id="non-pq-QWR"/>
                             <constraint firstAttribute="trailing" secondItem="SqD-jA-YKV" secondAttribute="trailing" id="qxK-In-OMO"/>
-                            <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="TBK-bI-lVF" secondAttribute="trailing" constant="30" id="u28-3r-V2B"/>
-                            <constraint firstItem="TBK-bI-lVF" firstAttribute="height" secondItem="5EZ-qb-Rvc" secondAttribute="height" multiplier="0.150298" id="vXS-9d-yiL"/>
-                            <constraint firstItem="TBK-bI-lVF" firstAttribute="top" secondItem="FqG-gg-gIl" secondAttribute="bottom" constant="10" id="xZR-YU-i2m"/>
+                            <constraint firstItem="TBK-bI-lVF" firstAttribute="trailing" secondItem="vDu-zF-Fre" secondAttribute="trailing" constant="-30" id="u28-3r-V2B"/>
+                            <constraint firstItem="FqG-gg-gIl" firstAttribute="bottom" secondItem="TBK-bI-lVF" secondAttribute="top" constant="-10" id="xZR-YU-i2m"/>
                         </constraints>
                     </view>
                     <tabBarItem key="tabBarItem" title="" image="home" selectedImage="home" id="ZN1-p6-8Xg"/>

--- a/Booster/Booster/Storyboards/Statistics.storyboard
+++ b/Booster/Booster/Storyboards/Statistics.storyboard
@@ -100,7 +100,7 @@
                         <color key="backgroundColor" name="boosterBackground"/>
                         <constraints>
                             <constraint firstItem="vFG-gS-Dc3" firstAttribute="leading" secondItem="5EZ-qb-Rvc" secondAttribute="leading" constant="20" id="04p-NS-IsF"/>
-                            <constraint firstItem="vDu-zF-Fre" firstAttribute="bottom" secondItem="vFG-gS-Dc3" secondAttribute="bottom" id="9UJ-an-SMe"/>
+                            <constraint firstItem="vFG-gS-Dc3" firstAttribute="bottom" secondItem="vDu-zF-Fre" secondAttribute="bottom" id="9UJ-an-SMe"/>
                             <constraint firstItem="vFG-gS-Dc3" firstAttribute="top" secondItem="zT5-Yx-3KO" secondAttribute="bottom" constant="5" id="F0G-sp-OTz"/>
                             <constraint firstItem="zT5-Yx-3KO" firstAttribute="top" secondItem="ZAm-ew-NSH" secondAttribute="bottom" constant="-5" id="GA5-ur-PUW"/>
                             <constraint firstAttribute="trailing" secondItem="vFG-gS-Dc3" secondAttribute="trailing" constant="20" id="Qz2-Ek-Vjn"/>

--- a/Booster/Booster/ViewControllers/Statistic/StatisticsViewController.swift
+++ b/Booster/Booster/ViewControllers/Statistic/StatisticsViewController.swift
@@ -155,20 +155,19 @@ final class StatisticsViewController: UIViewController, BaseViewControllerTempla
     }
 
     private func updateDuration(using statisticsCollection: StepStatisticsCollection) {
-        guard let stepRatios = statisticsCollection.stepRatios()?.map({ CGFloat($0) }),
-              let stepCount = statisticsCollection.stepCountPerDuration()
+        guard let stepCount = statisticsCollection.stepCountPerDuration()
         else { return }
 
         averageStepCountLabel.text = String(stepCount)
         dateLabel.text = statisticsCollection.durationString
 
         let strings = statisticsCollection.abbreviatedStrings()
+        let stepRatios = statisticsCollection.stepRatios().map { CGFloat($0) }
         chartView.drawChart(stepRatios: stepRatios, strings: strings)
     }
 
     private func updateSelection(using statisticsCollection: StepStatisticsCollection, index: Int?) {
-        guard let index = index,
-              let stepRatios = statisticsCollection.stepRatios()
+        guard let index = index
         else {
             chartView.clearSelection()
             return
@@ -177,6 +176,7 @@ final class StatisticsViewController: UIViewController, BaseViewControllerTempla
         let xOffset = 1 / CGFloat(statisticsCollection.count)
         let centerLabel = 0.5
         let xCoordinate = (centerLabel + CGFloat(index)) * xOffset * chartView.frame.width
+        let stepRatios = statisticsCollection.stepRatios()
         let height = 1 - CGFloat(stepRatios[index])
 
         let selectedStatistics: StepStatistics = statisticsCollection[index]

--- a/Booster/Podfile
+++ b/Booster/Podfile
@@ -8,6 +8,8 @@ def pods
   pod 'RxCocoa'
   pod 'RxDataSources'
   pod 'RxGesture'
+  pod 'RxTest'
+  pod 'RxBlocking'
 end
 
 target 'Booster' do

--- a/Booster/Podfile.lock
+++ b/Booster/Podfile.lock
@@ -1,5 +1,7 @@
 PODS:
   - Differentiator (5.0.0)
+  - RxBlocking (6.2.0):
+    - RxSwift (= 6.2.0)
   - RxCocoa (6.2.0):
     - RxRelay (= 6.2.0)
     - RxSwift (= 6.2.0)
@@ -13,30 +15,38 @@ PODS:
   - RxRelay (6.2.0):
     - RxSwift (= 6.2.0)
   - RxSwift (6.2.0)
+  - RxTest (6.2.0):
+    - RxSwift (= 6.2.0)
 
 DEPENDENCIES:
+  - RxBlocking
   - RxCocoa
   - RxDataSources
   - RxGesture
   - RxSwift
+  - RxTest
 
 SPEC REPOS:
   trunk:
     - Differentiator
+    - RxBlocking
     - RxCocoa
     - RxDataSources
     - RxGesture
     - RxRelay
     - RxSwift
+    - RxTest
 
 SPEC CHECKSUMS:
   Differentiator: e8497ceab83c1b10ca233716d547b9af21b9344d
+  RxBlocking: 0b29f7d2079109a8de49c411381bed7c33ef1eeb
   RxCocoa: 4baf94bb35f2c0ab31bc0cb9f1900155f646ba42
   RxDataSources: aa47cc1ed6c500fa0dfecac5c979b723542d79cf
   RxGesture: f059f2aeef966fb17dad56ee440e76410f10e55f
   RxRelay: e72dbfd157807478401ef1982e1c61c945c94b2f
   RxSwift: d356ab7bee873611322f134c5f9ef379fa183d8f
+  RxTest: 0c692fa672b694373ba86d2b00033595297a2831
 
-PODFILE CHECKSUM: ef6c423840d8dc11f186a7d82fdf7d634bb4136a
+PODFILE CHECKSUM: 67784840bd8f7839696259ef8099fcd6d86ff1fa
 
 COCOAPODS: 1.11.2

--- a/Booster/StatisticsTests/StatisticsViewModelTests.swift
+++ b/Booster/StatisticsTests/StatisticsViewModelTests.swift
@@ -7,26 +7,102 @@
 
 import XCTest
 
-class StatisticsViewModelTests: XCTestCase {
+import RxSwift
+import RxCocoa
+import RxTest
+import RxBlocking
+import HealthKit
 
+final class StatisticsViewModelTests: XCTestCase {
+    private var viewModel: StatisticsViewModel!
+    private var disposeBag: DisposeBag!
+    
     override func setUpWithError() throws {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
+        viewModel = StatisticsViewModel()
+        disposeBag = DisposeBag()
     }
 
     override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        viewModel = nil
+        disposeBag = nil
     }
-
-    func testExample() throws {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    
+    func test_바인드() throws {
+        // given
+        let newDuration: StatisticsViewModel.Duration = .year
+        
+        // when
+        viewModel.bind()
+        viewModel.selectedDuration.accept(newDuration)
+        let index: Int? = viewModel.selectedStatisticsIndex.value
+       
+        // then
+        XCTAssertNil(index)
     }
-
-    func testPerformanceExample() throws {
-        // This is an example of a performance test case.
-        self.measure {
-            // Put the code you want to measure the time of here.
-        }
+    
+    func test_쿼리요청해서_모델생성_성공() throws {
+        // given
+        let staitisticsUsecase = StatisticsUsecase()
+        var stepStatisticsCollection: StepStatisticsCollection?
+        let expectation = expectation(description: "Query")
+        
+        // when
+        staitisticsUsecase.execute(duration: .year, interval: .init(month: 1))
+            .subscribe({ queryResult in
+                stepStatisticsCollection = try? queryResult.get()
+                expectation.fulfill()
+            })
+            .disposed(by: disposeBag)
+        
+        //then
+        waitForExpectations(timeout: 2)
     }
-
+    
+    func test_처음탭했을때_인덱스생성_성공() throws {
+        // given
+        viewModel.requestQueryForStatisticsCollection()
+        sleep(1)
+        let mockCoordinate: Float = 1 / 7
+        
+        // when
+        viewModel.selectStatistics(tappedCoordinate: mockCoordinate)
+        let index: Int? = viewModel.selectedStatisticsIndex.value
+        
+        // then
+        XCTAssertNotNil(index)
+    }
+    
+    func test_탭한곳또탭했을때_인덱스삭제_성공() throws {
+        // given
+        viewModel.requestQueryForStatisticsCollection()
+        sleep(1)
+        let mockCoordinate: Float = 1 / 7
+        viewModel.selectStatistics(tappedCoordinate: mockCoordinate)
+        
+        // when
+        viewModel.selectStatistics(tappedCoordinate: mockCoordinate)
+        let index: Int? = viewModel.selectedStatisticsIndex.value
+        
+        // then
+        XCTAssertNil(index)
+    }
+    
+    func test_팬해서_인덱스변경_성공() throws {
+        // given
+        viewModel.requestQueryForStatisticsCollection()
+        sleep(1)
+        let count: Float = Float(try XCTUnwrap(viewModel.selectedStatisticsCollection()?.count))
+        let firstIndex = 0
+        let lastIndex = 1
+        let mockFirstCoordinate: Float = Float(firstIndex) / count
+        let mockSecondCoordinate: Float = Float(lastIndex) / count
+        viewModel.selectStatistics(tappedCoordinate: mockFirstCoordinate)
+        
+        // when
+        viewModel.selectStatistics(pannedCoordinate: mockSecondCoordinate)
+        let index: Int? = viewModel.selectedStatisticsIndex.value
+        
+        // then
+        XCTAssertTrue(index == lastIndex)
+    }
 }

--- a/Booster/StatisticsTests/StepStatisticsTests.swift
+++ b/Booster/StatisticsTests/StepStatisticsTests.swift
@@ -20,50 +20,24 @@ final class StepStatisticsTests: XCTestCase {
 
     func test_통계추가_성공() throws {
         // given
-        let stepStatistics = StepStatistics(step: 1, intervalString: String(), abbreviatedDateString: String())
+        let stepStatistics = StepStatistics(step: 1, abbreviatedDateString: String(), intervalString: String())
 
         // when
-        stepStatisticsCollection.append(statistics: statistics)
+        stepStatisticsCollection.append(stepStatistics)
         let resultStepStatistics: StepStatistics = stepStatisticsCollection[0]
 
         // then
-        XCTAssertEqual(statistics, resultStatistics)
-    }
-
-    func test_통계하나이상있을때_최대값통계_리턴_성공() throws {
-        // given
-        let stepFourStatistics = StepStatistics(step: 4, intervalString: String(), abbreviatedDateString: String())
-        let stepSixStatistics = StepStatistics(step: 6, intervalString: String(), abbreviatedDateString: String())
-        let stepFiveStatistics = StepStatistics(step: 5, intervalString: String(), abbreviatedDateString: String())
-        stepStatisticsCollection.append(statistics: stepFourStatistics)
-        stepStatisticsCollection.append(statistics: stepSixStatistics)
-        stepStatisticsCollection.append(statistics: stepFiveStatistics)
-
-        // when
-        let resultStatistics: StepStatistics? = stepStatisticsCollection.maxStepStatistics()
-
-        // then
-        XCTAssertEqual(stepSixStatistics, resultStatistics)
-    }
-
-    func test_통계하나도없을때_최대값통계_리턴_실패() throws {
-        // given
-
-        // when
-        let resultStepStatistics: StepStatistics? = stepStatisticsCollection.maxStepStatistics()
-
-        // then
-        XCTAssertNil(resultStepStatistics)
+        XCTAssertEqual(stepStatistics, resultStepStatistics)
     }
 
     func test_통계하나이상있을때_평균걸음수_리턴_성공() throws {
         // given
-        let stepFourStatistics = StepStatistics(step: 4, intervalString: String(), abbreviatedDateString: String())
-        let stepSixStatistics = StepStatistics(step: 6, intervalString: String(), abbreviatedDateString: String())
-        let stepFiveStatistics = StepStatistics(step: 5, intervalString: String(), abbreviatedDateString: String())
-        stepStatisticsCollection.append(statistics: stepFourStatistics)
-        stepStatisticsCollection.append(statistics: stepSixStatistics)
-        stepStatisticsCollection.append(statistics: stepFiveStatistics)
+        let stepFourStatistics = StepStatistics(step: 4, abbreviatedDateString: String(), intervalString: String())
+        let stepSixStatistics = StepStatistics(step: 6, abbreviatedDateString: String(), intervalString: String())
+        let stepFiveStatistics = StepStatistics(step: 5, abbreviatedDateString: String(), intervalString: String())
+        stepStatisticsCollection.append(stepFourStatistics)
+        stepStatisticsCollection.append(stepSixStatistics)
+        stepStatisticsCollection.append(stepFiveStatistics)
 
         // when
         let stepCountPerDuration: Int? = stepStatisticsCollection.stepCountPerDuration()
@@ -84,12 +58,12 @@ final class StepStatisticsTests: XCTestCase {
 
     func test_통계하나이상있을때_걸음비율_리턴_성공() throws {
         // given
-        let stepFourStatistics = StepStatistics(step: 2, intervalString: String(), abbreviatedDateString: String())
-        let stepSixStatistics = StepStatistics(step: 4, intervalString: String(), abbreviatedDateString: String())
-        let stepFiveStatistics = StepStatistics(step: 8, intervalString: String(), abbreviatedDateString: String())
-        stepStatisticsCollection.append(statistics: stepFourStatistics)
-        stepStatisticsCollection.append(statistics: stepSixStatistics)
-        stepStatisticsCollection.append(statistics: stepFiveStatistics)
+        let stepFourStatistics = StepStatistics(step: 2, abbreviatedDateString: String(), intervalString: String())
+        let stepSixStatistics = StepStatistics(step: 4, abbreviatedDateString: String(), intervalString: String())
+        let stepFiveStatistics = StepStatistics(step: 8, abbreviatedDateString: String(), intervalString: String())
+        stepStatisticsCollection.append(stepFourStatistics)
+        stepStatisticsCollection.append(stepSixStatistics)
+        stepStatisticsCollection.append(stepFiveStatistics)
 
         // when
         let stepRatios: [Float]? = stepStatisticsCollection.stepRatios()
@@ -102,9 +76,9 @@ final class StepStatisticsTests: XCTestCase {
         // given
 
         // when
-        let stepRatios: [Float]? = stepStatisticsCollection.stepRatios()
+        let stepRatios: [Float] = stepStatisticsCollection.stepRatios()
 
         // then
-        XCTAssertNil(stepRatios)
+        XCTAssertTrue(stepRatios.isEmpty)
     }
 }


### PR DESCRIPTION
### 작업 내용
- ChartView의 CATextLayer fontSize가 14인데
ChartView의 height가 fontSize의 10배보다 작으면 하단이 짤리는 버그
-> 홈탭의 ChartView크기를 140으로 고정

### 하고싶은 말
화면이 더 작은 기기(height면에서)가 등장하면 중앙에 있는 goal과 하단의 hourly가 만날 가능성이 존재. 