### PR TITLE
[E] 푸시 알람

### DIFF
--- a/Booster/Booster.xcodeproj/project.pbxproj
+++ b/Booster/Booster.xcodeproj/project.pbxproj
@@ -141,6 +141,7 @@
 		FAB252CC2753D1AF00A4FC5B /* MilestoneTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAB252CB2753D1AF00A4FC5B /* MilestoneTests.swift */; };
 		FAB252D22753D57000A4FC5B /* Milestone.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA614F312733CDAA00B090D9 /* Milestone.swift */; };
 		FAB252D32753D6D700A4FC5B /* Coordinate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA614F332733CDAA00B090D9 /* Coordinate.swift */; };
+		FAB252D92754B07400A4FC5B /* BoosterUserNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAB252D82754B07400A4FC5B /* BoosterUserNotification.swift */; };
 		FACBAB6A2746034900CD6B76 /* UIButton+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = FACBAB692746034900CD6B76 /* UIButton+Extension.swift */; };
 		FADAC0D02745F55100A026E2 /* EditUserInfoTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = FADAC0CF2745F55100A026E2 /* EditUserInfoTextField.swift */; };
 /* End PBXBuildFile section */
@@ -306,6 +307,7 @@
 		FAB252BD2753C5EB00A4FC5B /* CoordinateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoordinateTests.swift; sourceTree = "<group>"; };
 		FAB252C92753D1AF00A4FC5B /* MilestoneTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MilestoneTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		FAB252CB2753D1AF00A4FC5B /* MilestoneTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MilestoneTests.swift; sourceTree = "<group>"; };
+		FAB252D82754B07400A4FC5B /* BoosterUserNotification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoosterUserNotification.swift; sourceTree = "<group>"; };
 		FACBAB692746034900CD6B76 /* UIButton+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIButton+Extension.swift"; sourceTree = "<group>"; };
 		FADAC0CF2745F55100A026E2 /* EditUserInfoTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditUserInfoTextField.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -830,6 +832,7 @@
 			children = (
 				FA614F532733CDAA00B090D9 /* HealthStoreManager.swift */,
 				37FD1AED274D1D6600FAB0CC /* HealthKitManager.swift */,
+				FAB252D82754B07400A4FC5B /* BoosterUserNotification.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -1274,6 +1277,7 @@
 				FA614F852733CDAA00B090D9 /* TrackingMapView.swift in Sources */,
 				28C9703B274C84DC005BD7BC /* ModifyFeedUsecase.swift in Sources */,
 				FA473A4B2743A2FB0000C5DC /* UserUsecase.swift in Sources */,
+				FAB252D92754B07400A4FC5B /* BoosterUserNotification.swift in Sources */,
 				FA614F5E2733CDAA00B090D9 /* TrackingProgressViewModel.swift in Sources */,
 				FA614F7D2733CDAA00B090D9 /* SceneDelegate.swift in Sources */,
 				FADAC0D02745F55100A026E2 /* EditUserInfoTextField.swift in Sources */,

--- a/Booster/Booster/AppDelegates/AppDelegate.swift
+++ b/Booster/Booster/AppDelegates/AppDelegate.swift
@@ -6,7 +6,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         let center = UNUserNotificationCenter.current()
         center.requestAuthorization(options: [.alert], completionHandler: { _, _ in
+            let boosterUserNotification = BoosterUserNotification()
+            if !boosterUserNotification.isAlreadyAdded(type: .morning) { boosterUserNotification.updateNotification(requestType: .add, type: .morning)}
         })
+        
         return true
     }
 

--- a/Booster/Booster/AppDelegates/AppDelegate.swift
+++ b/Booster/Booster/AppDelegates/AppDelegate.swift
@@ -7,7 +7,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         let center = UNUserNotificationCenter.current()
         center.requestAuthorization(options: [.alert], completionHandler: { _, _ in
             let boosterUserNotification = BoosterUserNotification()
-            if !boosterUserNotification.isAlreadyAdded(type: .morning) { boosterUserNotification.updateNotification(requestType: .add, type: .morning)}
+            if !boosterUserNotification.isAlreadyAdded(type: .morning) { boosterUserNotification.setNotification(requestType: .add, type: .morning)}
         })
         
         return true

--- a/Booster/Booster/Services/BoosterUserNotification.swift
+++ b/Booster/Booster/Services/BoosterUserNotification.swift
@@ -77,7 +77,7 @@ final class BoosterUserNotification {
                                                         trigger: notificationTrigger)
 
         UNUserNotificationCenter.current().add(notificationRequest) { error in
-            print("## \(error?.localizedDescription)")
+            
         }
     }
     
@@ -97,7 +97,6 @@ final class BoosterUserNotification {
                                                         trigger: nil)
 
         UNUserNotificationCenter.current().add(notificationRequest) { [weak self] error in
-            print("## \(error?.localizedDescription)")
             self?.removeGoalNotification()
         }
     }

--- a/Booster/Booster/Services/BoosterUserNotification.swift
+++ b/Booster/Booster/Services/BoosterUserNotification.swift
@@ -1,0 +1,108 @@
+//
+//  BoosterNotification.swift
+//  Booster
+//
+//  Created by mong on 2021/11/29.
+//
+
+import UIKit
+
+final class BoosterUserNotification {
+    enum NotificationType: String {
+        case morning
+        case goal
+    }
+    
+    enum NotificationRequestType {
+        case add
+        case remove
+    }
+    
+    private let notificationContent = UNMutableNotificationContent()
+    
+    func isAlreadyAdded(type: NotificationType) -> Bool {
+        var isAdded = false
+        UNUserNotificationCenter.current().getPendingNotificationRequests(completionHandler: { requests in
+            requests.forEach {
+                if $0.identifier == type.rawValue {
+                    isAdded = true
+                    return
+                }
+            }
+        })
+        
+        return isAdded
+    }
+    
+    func setNotification(requestType: NotificationRequestType, type: NotificationType) {
+        switch requestType {
+        case .add:
+            addNotification(type: type)
+        case .remove:
+            removeNotification(type: type)
+        }
+    }
+    
+    private func addNotification(type: NotificationType) {
+        switch type {
+        case .morning:
+            addMorningNotification()
+        case .goal:
+            addGoalNotification()
+        }
+    }
+    
+    private func removeNotification(type: NotificationType) {
+        switch type {
+        case .morning:
+            removeMorningNotification()
+        case .goal:
+            removeGoalNotification()
+        }
+    }
+    
+    private func addMorningNotification() {
+        let title = "아침이 밝았어요!"
+        let body = "오늘 하루도 산책으로 분위기를 환기시키는게 어때요?"
+        notificationContent.title = title
+        notificationContent.body = body
+
+        var dateComponents = DateComponents()
+        dateComponents.hour = 9
+
+        let notificationTrigger = UNCalendarNotificationTrigger(dateMatching: dateComponents, repeats: true)
+
+        let notificationRequest = UNNotificationRequest(identifier: NotificationType.morning.rawValue,
+                                                        content: notificationContent,
+                                                        trigger: notificationTrigger)
+
+        UNUserNotificationCenter.current().add(notificationRequest) { error in
+            print("## \(error?.localizedDescription)")
+        }
+    }
+    
+    private func removeMorningNotification() {
+        UNUserNotificationCenter.current().removePendingNotificationRequests(withIdentifiers: [NotificationType.morning.rawValue])
+    }
+    
+    private func addGoalNotification() {
+        let title = "축하합니다!"
+        let body = "목표 걸음수에 도달했어요!"
+        notificationContent.title = title
+        notificationContent.body = body
+
+        
+        let notificationRequest = UNNotificationRequest(identifier: NotificationType.goal.rawValue,
+                                                        content: notificationContent,
+                                                        trigger: nil)
+
+        UNUserNotificationCenter.current().add(notificationRequest) { [weak self] error in
+            print("## \(error?.localizedDescription)")
+            self?.removeGoalNotification()
+        }
+    }
+    
+    private func removeGoalNotification() {
+        UNUserNotificationCenter.current().removePendingNotificationRequests(withIdentifiers: [NotificationType.goal.rawValue])
+    }
+}


### PR DESCRIPTION
### 작업 내용
매일 9시에 산책을 권장하는 Push 알림 표시.
목표 걸음수 도달 Push 알림 표시 로직 구현
### 체크리스트
- [x] #195 푸시 알람 기능 구현 

### 구현 설명
```swift
let boosterUserNotification = BoosterUserNotification()
boosterUserNotification.setNotification(requestType: .add, type: .goal)
```
이렇게 추가하시면 되며 goal의 경우에는 일회성 Push로 판단해 setNotification의 add를 요청하고 Push 알림의 실행 후 해당 Push 이벤트를 등록 해제시켜 주었습니다.
**즉 Goal에 한해서만 해당 로직을 사용하시면 되고** 매일 아침 Push의 경우에는 `isAlreadyAdded`를 통해서 존재하는지 확인 후 삭제하고 새로 등록하셔야지만 Push 알림이 중복이 안됩니다!
### 하고싶은 말
